### PR TITLE
Add a markdown parser to convert then render markdown content to annotated string

### DIFF
--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -48,15 +48,19 @@ fun ChatMessageItem(message: ChatMessage) {
                 .fillMaxWidth()
                 .padding(12.dp)
         ) {
-            Text(
-                text = message.text,
-                style = MaterialTheme.typography.bodyLarge,
-                color = if (message.isFromUser) {
-                    MaterialTheme.colorScheme.onPrimaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                }
-            )
+            // Use ConciergeResponse composable for response messages to support markdown formatting
+            if (message.isFromUser) {
+                Text(
+                    text = message.text,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            } else {
+                ConciergeResponse(
+                    text = message.text,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
             
             Text(
                 text = if (message.isFromUser) "You" else "Assistant",

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ConciergeResponse.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ConciergeResponse.kt
@@ -37,7 +37,7 @@ fun ConciergeResponse(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val annotatedString = MarkdownParser.Companion.parse(text)
+    val annotatedString = MarkdownParser.parse(text)
     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
     
     BasicText(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ConciergeResponse.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ConciergeResponse.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.components.messages
+
+import android.content.Intent
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextLayoutResult
+import com.adobe.marketing.mobile.concierge.utils.markdown.MarkdownParser
+import androidx.core.net.toUri
+
+/**
+ * Component that renders brand concierge responses containing markdown text
+ * with proper styling and clickable links.
+ * 
+ * @param text The markdown text to be rendered
+ * @param modifier Optional modifier for the text component
+ */
+@Composable
+fun ConciergeResponse(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val annotatedString = MarkdownParser.Companion.parse(text)
+    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    
+    BasicText(
+        text = annotatedString,
+        modifier = modifier
+            .fillMaxWidth()
+            .pointerInput(Unit) {
+                detectTapGestures { tapOffsetPosition ->
+                    val layoutResult = textLayoutResult ?: return@detectTapGestures
+                    val position = layoutResult.getOffsetForPosition(tapOffsetPosition)
+                    
+                    annotatedString
+                        .getStringAnnotations(start = position, end = position)
+                        .firstOrNull { it.tag == "URL" }
+                        ?.let { annotation ->
+                            val intent = Intent(Intent.ACTION_VIEW, annotation.item.toUri())
+                            context.startActivity(intent)
+                        }
+                }
+            },
+        onTextLayout = { result ->
+            textLayoutResult = result
+        }
+    )
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/MessageList.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/MessageList.kt
@@ -12,7 +12,6 @@
 
 package com.adobe.marketing.mobile.concierge.ui.components.messages
 
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParser.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import com.adobe.marketing.mobile.concierge.ConciergeConstants
+import com.adobe.marketing.mobile.services.Log
+
+/**
+ * Core class that manages the parsing workflow via the [MarkdownTokenizer] and [MarkdownRenderer]
+ * objects.
+ */
+internal class MarkdownParser {
+    companion object {
+        private val tokenizer = MarkdownTokenizer()
+        private val renderer = MarkdownRenderer()
+
+        /**
+         * Parses the provided markdown string and returns an [AnnotatedString] with the appropriate
+         * styling applied.
+         *
+         * @param markdown The markdown string to parse.
+         * @return An [AnnotatedString] with the appropriate styling applied.
+         */
+        @JvmStatic
+        fun parse(markdown: String): AnnotatedString {
+            val tokens = tokenizer.tokenize(markdown)
+            Log.debug(ConciergeConstants.EXTENSION_NAME, "parse", "Parsed ${tokens.size} tokens, starting rendering.")
+            val result = renderer.render(markdown, tokens)
+            return result
+        }
+    }
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParser.kt
@@ -20,24 +20,23 @@ import com.adobe.marketing.mobile.services.Log
  * Core class that manages the parsing workflow via the [MarkdownTokenizer] and [MarkdownRenderer]
  * objects.
  */
-internal class MarkdownParser {
-    companion object {
-        private val tokenizer = MarkdownTokenizer()
-        private val renderer = MarkdownRenderer()
-
-        /**
-         * Parses the provided markdown string and returns an [AnnotatedString] with the appropriate
-         * styling applied.
-         *
-         * @param markdown The markdown string to parse.
-         * @return An [AnnotatedString] with the appropriate styling applied.
-         */
-        @JvmStatic
-        fun parse(markdown: String): AnnotatedString {
-            val tokens = tokenizer.tokenize(markdown)
-            Log.debug(ConciergeConstants.EXTENSION_NAME, "parse", "Parsed ${tokens.size} tokens, starting rendering.")
-            val result = renderer.render(markdown, tokens)
-            return result
-        }
+internal object MarkdownParser {
+    /**
+     * Parses the provided markdown string and returns an [AnnotatedString] with the appropriate
+     * styling applied.
+     *
+     * @param markdown The markdown string to parse.
+     * @return An [AnnotatedString] with the appropriate styling applied.
+     */
+    @JvmStatic
+    fun parse(markdown: String): AnnotatedString {
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        Log.debug(
+            ConciergeConstants.EXTENSION_NAME,
+            "parse",
+            "Parsed ${tokens.size} tokens, starting rendering."
+        )
+        val result = MarkdownRenderer.render(markdown, tokens)
+        return result
     }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRenderer.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRenderer.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import com.adobe.marketing.mobile.concierge.ConciergeConstants
+import com.adobe.marketing.mobile.services.Log
+
+/**
+ * Handles the rendering of tokens into an [AnnotatedString].
+ */
+internal class MarkdownRenderer {
+
+    /**
+     * Renders the provided list of [MarkdownToken]s into an [AnnotatedString].
+     *
+     * @param markdown The original markdown string.
+     * @param tokens The list of [MarkdownToken]s to render.
+     * @return An [AnnotatedString] with the appropriate styling applied.
+     */
+    fun render(markdown: String, tokens: List<MarkdownToken>): AnnotatedString {
+        Log.debug(ConciergeConstants.EXTENSION_NAME, "render", "Starting rendering of ${tokens.size} tokens")
+        val builder = AnnotatedString.Builder()
+        var currentIndex = 0
+        
+        tokens.forEach { token ->
+            if (token.start < currentIndex) return@forEach
+            
+            appendGapText(markdown, currentIndex, token.start, builder)
+            currentIndex = token.start
+            renderToken(token, builder)
+            currentIndex = token.end
+        }
+        
+        appendGapText(markdown, currentIndex, markdown.length, builder)
+        
+        Log.debug(ConciergeConstants.EXTENSION_NAME, "render", "Rendering completed, final text length: ${builder.length}")
+        return builder.toAnnotatedString()
+    }
+    
+    private fun appendGapText(
+        markdown: String, 
+        from: Int, 
+        to: Int, 
+        builder: AnnotatedString.Builder
+    ) {
+        if (from < to) {
+            builder.append(markdown.substring(from, to))
+        }
+    }
+    
+    private fun renderToken(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        when (token.type) {
+            TokenType.CODE_BLOCK -> renderCodeBlock(token, builder)
+            TokenType.INLINE_CODE -> renderInlineCode(token, builder)
+            TokenType.LINK -> renderLink(token, builder)
+            TokenType.BOLD -> renderBold(token, builder)
+            TokenType.ITALIC -> renderItalic(token, builder)
+            TokenType.HEADING -> renderHeading(token, builder)
+            TokenType.LIST -> renderList(token, builder)
+            TokenType.BLOCKQUOTE -> renderBlockquote(token, builder)
+        }
+    }
+    
+    private fun renderCodeBlock(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val codeContent = token.groups[0].trim()
+        val styleStart = builder.length
+        
+        builder.append(codeContent)
+        builder.addStyle(MarkdownStyles.codeBlockStyle(), styleStart, builder.length)
+    }
+    
+    private fun renderInlineCode(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val codeContent = token.groups[0]
+        val styleStart = builder.length
+        
+        builder.append(codeContent)
+        builder.addStyle(MarkdownStyles.inlineCodeStyle(), styleStart, builder.length)
+    }
+    
+    private fun renderLink(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val (linkText, linkUrl) = token.groups
+        val styleStart = builder.length
+        
+        builder.append(linkText)
+        builder.addStyle(MarkdownStyles.linkStyle(), styleStart, builder.length)
+        
+        builder.addStringAnnotation(
+            tag = "URL",
+            annotation = linkUrl,
+            start = styleStart,
+            end = builder.length
+        )
+    }
+    
+    private fun renderBold(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val boldContent = token.groups[0]
+        val styleStart = builder.length
+        
+        builder.append(boldContent)
+        builder.addStyle(MarkdownStyles.BOLD_STYLE, styleStart, builder.length)
+    }
+    
+    private fun renderItalic(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val italicContent = token.groups[0]
+        val styleStart = builder.length
+        
+        builder.append(italicContent)
+        builder.addStyle(MarkdownStyles.ITALIC_STYLE, styleStart, builder.length)
+    }
+    
+    private fun renderHeading(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val headingLevel = token.groups[0].length // # or ##
+        val headingText = token.groups[1]
+        val styleStart = builder.length
+        
+        builder.append(headingText)
+        builder.addStyle(MarkdownStyles.headingStyle(headingLevel), styleStart, builder.length)
+    }
+    
+    private fun renderList(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val listItem = token.groups[0]
+        builder.append("• $listItem\n")
+    }
+    
+    private fun renderBlockquote(token: MarkdownToken, builder: AnnotatedString.Builder) {
+        val quoteText = token.groups[0]
+        val styleStart = builder.length
+        
+        builder.append(quoteText)
+        builder.addStyle(MarkdownStyles.blockquoteStyle(), styleStart, builder.length)
+        builder.append("\n")
+    }
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRenderer.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRenderer.kt
@@ -19,7 +19,7 @@ import com.adobe.marketing.mobile.services.Log
 /**
  * Handles the rendering of tokens into an [AnnotatedString].
  */
-internal class MarkdownRenderer {
+internal object MarkdownRenderer {
 
     /**
      * Renders the provided list of [MarkdownToken]s into an [AnnotatedString].

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownStyles.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Centralized styling constants for markdown elements.
+ */
+internal object MarkdownStyles {
+    
+    // Color constants
+    val H1_COLOR = Color(0xFFA75CF2)
+    val H2_COLOR = Color(0xFF48D883)
+    val CODE_BLOCK_BACKGROUND = Color(0xFFEFEFEF)
+    val CODE_BLOCK_TEXT = Color(0xFF333333)
+    val BLOCKQUOTE_BACKGROUND = Color(0xFFE0E0E0)
+    val LINK_COLOR = Color.Blue
+    
+    // Font sizes
+    val H1_FONT_SIZE = 26.sp
+    val H2_FONT_SIZE = 22.sp
+    val CODE_BLOCK_FONT_SIZE = 16.sp
+    val INLINE_CODE_FONT_SIZE = 14.sp
+    
+    // Font families
+    val MONOSPACE_FONT = FontFamily.Monospace
+    
+    // Styles
+    val BOLD_STYLE = SpanStyle(fontWeight = FontWeight.Bold)
+    val ITALIC_STYLE = SpanStyle(fontStyle = FontStyle.Italic)
+
+    fun headingStyle(level: Int): SpanStyle {
+        return SpanStyle(
+            fontSize = if (level == 1) H1_FONT_SIZE else H2_FONT_SIZE,
+            fontWeight = FontWeight.Bold,
+            color = if (level == 1) H1_COLOR else H2_COLOR
+        )
+    }
+    
+    fun codeBlockStyle(): SpanStyle {
+        return SpanStyle(
+            background = CODE_BLOCK_BACKGROUND,
+            color = CODE_BLOCK_TEXT,
+            fontSize = CODE_BLOCK_FONT_SIZE,
+            fontFamily = MONOSPACE_FONT
+        )
+    }
+    
+    fun inlineCodeStyle(): SpanStyle {
+        return SpanStyle(
+            background = Color.LightGray,
+            fontSize = INLINE_CODE_FONT_SIZE,
+            fontFamily = MONOSPACE_FONT
+        )
+    }
+    
+    fun linkStyle(): SpanStyle {
+        return SpanStyle(
+            color = LINK_COLOR,
+            textDecoration = TextDecoration.Underline
+        )
+    }
+    
+    fun blockquoteStyle(): SpanStyle {
+        return SpanStyle(
+            background = BLOCKQUOTE_BACKGROUND,
+            fontStyle = FontStyle.Italic
+        )
+    }
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import com.adobe.marketing.mobile.concierge.ConciergeConstants
+import com.adobe.marketing.mobile.services.Log
+
+/**
+ * Handles the tokenization of markdown text into structured tokens.
+ */
+internal class MarkdownTokenizer {
+
+    /**
+     * Tokenizes the given markdown string into a list of [MarkdownToken] objects.
+     *
+     * The order of pattern matching is important to avoid conflicts, especially with links.
+     * Links are processed first to ensure they are not broken up by other patterns.
+     *
+     * @param markdown The markdown string to tokenize.
+     * @return A list of [MarkdownToken] objects representing the parsed tokens.
+     */
+    fun tokenize(markdown: String): List<MarkdownToken> {
+        val tokens = mutableListOf<MarkdownToken>()
+        
+        // First, find all links
+        val linkPattern = """\[(.*?)\]\((.*?)\)""".toRegex()
+        linkPattern.findAll(markdown).forEach { result ->
+            val matchedGroups = (1..result.groups.size - 1)
+                .map { i -> result.groups[i]?.value ?: "" }
+            
+            tokens += MarkdownToken(
+                type = TokenType.LINK,
+                start = result.range.first,
+                end = result.range.last + 1,
+                groups = matchedGroups
+            )
+        }
+        
+        // Then find other patterns, but skip if they overlap with existing tokens
+        val otherPatterns = mapOf(
+            TokenType.CODE_BLOCK to """```([\s\S]*?)```""".toRegex(),
+            TokenType.INLINE_CODE to """`(.*?)`""".toRegex(),
+            TokenType.HEADING to """^(#{1,2})\s*(.*)""".toRegex(RegexOption.MULTILINE),
+            TokenType.LIST to """^- (.*)""".toRegex(RegexOption.MULTILINE),
+            TokenType.BLOCKQUOTE to """^>\s+(.*)""".toRegex(RegexOption.MULTILINE),
+            TokenType.ITALIC to """\*(.*?)\*""".toRegex(),
+            TokenType.BOLD to """\*\*(.*?)\*\*""".toRegex()
+        )
+        
+        otherPatterns.forEach { (type, pattern) ->
+            addMatchesIfNoOverlap(markdown, pattern, type, tokens)
+        }
+        
+        val sortedTokens = tokens.sortedBy { it.start }
+        Log.debug(ConciergeConstants.EXTENSION_NAME, "tokenize", "Total tokens found: ${sortedTokens.size}")
+        sortedTokens.forEach { token ->
+            Log.debug(ConciergeConstants.EXTENSION_NAME, "tokenize", "Token: $token")
+        }
+        
+        return sortedTokens
+    }
+    
+    private fun addMatchesIfNoOverlap(
+        markdown: String, 
+        pattern: Regex, 
+        type: TokenType, 
+        tokens: MutableList<MarkdownToken>
+    ) {
+        pattern.findAll(markdown).forEach { result ->
+            val newToken = MarkdownToken(
+                type = type,
+                start = result.range.first,
+                end = result.range.last + 1,
+                groups = (1..result.groups.size - 1).map { i -> result.groups[i]?.value ?: "" }
+            )
+            
+            // Only add if it doesn't overlap with existing tokens
+            val hasOverlap = tokens.any { existing ->
+                (newToken.start < existing.end && newToken.end > existing.start)
+            }
+            
+            if (!hasOverlap) {
+                tokens += newToken
+            }
+        }
+    }
+}
+
+/**
+ * Data class representing a parsed markdown token
+ */
+internal data class MarkdownToken(
+    val type: TokenType,
+    val start: Int,
+    val end: Int,
+    val groups: List<String>
+)
+
+/**
+ * Enum representing different types of markdown tokens
+ */
+internal enum class TokenType {
+    CODE_BLOCK,
+    INLINE_CODE,
+    LINK,
+    BOLD,
+    ITALIC,
+    HEADING,
+    LIST,
+    BLOCKQUOTE
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
@@ -18,7 +18,7 @@ import com.adobe.marketing.mobile.services.Log
 /**
  * Handles the tokenization of markdown text into structured tokens.
  */
-internal class MarkdownTokenizer {
+internal object MarkdownTokenizer {
 
     /**
      * Tokenizes the given markdown string into a list of [MarkdownToken] objects.
@@ -53,8 +53,8 @@ internal class MarkdownTokenizer {
             TokenType.HEADING to """^(#{1,2})\s*(.*)""".toRegex(RegexOption.MULTILINE),
             TokenType.LIST to """^- (.*)""".toRegex(RegexOption.MULTILINE),
             TokenType.BLOCKQUOTE to """^>\s+(.*)""".toRegex(RegexOption.MULTILINE),
-            TokenType.ITALIC to """\*(.*?)\*""".toRegex(),
-            TokenType.BOLD to """\*\*(.*?)\*\*""".toRegex()
+            TokenType.BOLD to """\*\*(.*?)\*\*""".toRegex(),
+            TokenType.ITALIC to """\*(.*?)\*""".toRegex()
         )
         
         otherPatterns.forEach { (type, pattern) ->

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParserTest.kt
@@ -14,9 +14,6 @@ package com.adobe.marketing.mobile.concierge.utils.markdown
 import org.junit.Test
 import org.junit.Assert.*
 
-/**
- * Tests for the MarkdownParser functionality
- */
 class MarkdownParserTest {
 
     @Test

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownParserTest.kt
@@ -1,0 +1,196 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Tests for the MarkdownParser functionality
+ */
+class MarkdownParserTest {
+
+    @Test
+    fun `test bold text parsing`() {
+        val markdown = "This is **bold** text"
+        val result = MarkdownParser.parse(markdown)
+        
+        // Check that the text contains the bold content
+        assertTrue(result.text.contains("bold"))
+    }
+
+    @Test
+    fun `test italic text parsing`() {
+        val markdown = "This is *italic* text"
+        val result = MarkdownParser.parse(markdown)
+        
+        assertTrue(result.text.contains("italic"))
+    }
+
+    @Test
+    fun `test heading parsing`() {
+        val markdown = "# Main Heading\n## Sub Heading"
+        val result = MarkdownParser.parse(markdown)
+        
+        assertTrue(result.text.contains("Main Heading"))
+        assertTrue(result.text.contains("Sub Heading"))
+    }
+
+    @Test
+    fun `test link parsing`() {
+        val markdown = "[Click here](https://example.com)"
+        val result = MarkdownParser.parse(markdown)
+        
+        assertTrue(result.text.contains("Click here"))
+        
+        // Check that string annotations are added for links
+        val annotations = result.getStringAnnotations("URL", 0, result.length)
+        assertFalse(annotations.isEmpty())
+        assertEquals("https://example.com", annotations[0].item)
+    }
+
+    @Test
+    fun `test code block parsing`() {
+        val markdown = "```\nfun test() {}\n\n```"
+        val result = MarkdownParser.parse(markdown)
+        
+        assertTrue(result.text.contains("fun test() {}"))
+    }
+
+    @Test
+    fun `test inline code parsing`() {
+        val markdown = "Use `println()` function"
+        val result = MarkdownParser.parse(markdown)
+
+        assertTrue(result.text.contains("println()"))
+    }
+
+    @Test
+    fun `test list parsing`() {
+        val markdown = "- First item\n- Second item"
+        val result = MarkdownParser.parse(markdown)
+
+        assertTrue(result.text.contains("• First item"))
+        assertTrue(result.text.contains("• Second item"))
+    }
+
+    @Test
+    fun `test blockquote parsing`() {
+        val markdown = "> This is a quote"
+        val result = MarkdownParser.parse(markdown)
+
+        assertTrue(result.text.contains("This is a quote"))
+    }
+
+    @Test
+    fun `test mixed markdown elements`() {
+        val markdown = """
+            # Title
+            
+            This is **bold** and *italic* text.
+            
+            [Link](https://example.com)
+            
+            - List item
+            - Another item
+            
+            > Quote here
+            
+            `inline code`
+        """.trimIndent()
+        
+        val result = MarkdownParser.parse(markdown)
+
+        assertTrue(result.text.contains("Title"))
+        assertTrue(result.text.contains("bold"))
+        assertTrue(result.text.contains("italic"))
+        assertTrue(result.text.contains("Link"))
+        assertTrue(result.text.contains("List item"))
+        assertTrue(result.text.contains("Quote here"))
+        assertTrue(result.text.contains("inline code"))
+    }
+
+    @Test
+    fun `test empty string`() {
+        val result = MarkdownParser.parse("")
+        assertEquals("", result.text)
+    }
+
+    @Test
+    fun `test plain text without markdown`() {
+        val plainText = "This is just plain text without any markdown formatting."
+        val result = MarkdownParser.parse(plainText)
+
+        assertEquals(plainText, result.text)
+    }
+
+    @Test
+    fun `test real-world beach destinations message`() {
+        val beachMessage = """
+            Looking for a beach trip for your summer getaway? Here are some fantastic beach destinations to consider:
+
+            1. **[Miami](https://www.southwestvacations.com/destinations/united-states/miami-vacation-packages-mf1)** - Known for its vibrant nightlife and beautiful sandy shores, Miami is perfect for those who want to soak up the sun and enjoy a lively atmosphere.
+
+            2. **[Fort Lauderdale](https://www.southwestvacations.com/destinations/united-states/fort-lauderdale-vacation-packages-fll)** - Famous for its boating canals and stunning beaches, Fort Lauderdale offers a relaxed beach vibe along with plenty of water activities.
+
+            3. **[Destin](https://www.southwestvacations.com/destinations/united-states/south-walton-beach-destin-vacation-packages-ec1)** - Renowned for its emerald waters and sugar-white sand beaches, Destin is a great choice for families and beach lovers looking for fun in the sun.
+
+            4. **[Pensacola](https://www.southwestvacations.com/destinations/united-states/pensacola-vacation-packages-pns)** - With its rich history and beautiful beaches, Pensacola provides a mix of cultural attractions and outdoor activities, making it a diverse getaway option.
+
+            5. **[Naples](https://www.southwestvacations.com/destinations/united-states/naples-vacation-packages-na3/)** - Enjoy over ten miles of stunning white sand beaches and clear Gulf waters, along with a vibrant dining scene and family-friendly activities.
+
+            Each of these destinations offers a unique beach experience, so you can find the perfect spot for your summer escape! If you'd like more information on any of these locations, just let me know!
+        """.trimIndent()
+
+        val result = MarkdownParser.parse(beachMessage)
+
+        // Verify bold text is parsed (destinations like Miami, Fort Lauderdale, etc.)
+        assertTrue(result.text.contains("Miami"))
+        assertTrue(result.text.contains("Fort Lauderdale"))
+        assertTrue(result.text.contains("Destin"))
+        assertTrue(result.text.contains("Pensacola"))
+        assertTrue(result.text.contains("Naples"))
+        
+        // Verify links are properly parsed and contain URL annotations
+        val annotations = result.getStringAnnotations("URL", 0, result.length)
+        assertFalse("Should have URL annotations for links", annotations.isEmpty())
+        
+        // Verify specific URLs are present
+        val urls = annotations.map { it.item }
+        assertTrue("Should contain Miami URL", urls.any { it.contains("miami-vacation-packages") })
+        assertTrue("Should contain Fort Lauderdale URL", urls.any { it.contains("fort-lauderdale-vacation-packages") })
+        assertTrue("Should contain Destin URL", urls.any { it.contains("destin-vacation-packages") })
+        assertTrue("Should contain Pensacola URL", urls.any { it.contains("pensacola-vacation-packages") })
+        assertTrue("Should contain Naples URL", urls.any { it.contains("naples-vacation-packages") })
+        
+        // Verify the text flows naturally without markdown syntax
+        assertFalse("Should not contain raw markdown syntax", result.text.contains("**[Miami]("))
+        assertFalse("Should not contain raw markdown syntax", result.text.contains("**["))
+        assertFalse("Should not contain raw markdown syntax", result.text.contains(")**"))
+    }
+
+    @Test
+    fun `test simple bold link combination`() {
+        val simpleMessage = "**[Miami](https://example.com)**"
+        val result = MarkdownParser.parse(simpleMessage)
+        
+        val annotations = result.getStringAnnotations("URL", 0, result.length)
+        
+        // Should have URL annotation
+        assertFalse("Should have URL annotation for simple bold link", annotations.isEmpty())
+        assertEquals("https://example.com", annotations[0].item)
+        
+        // Should contain the text without markdown
+        assertTrue(result.text.contains("Miami"))
+        assertFalse(result.text.contains("**[Miami]("))
+    }
+}

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRendererTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownRendererTest.kt
@@ -1,0 +1,424 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.concierge.utils.markdown
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
+import org.junit.Test
+import org.junit.Assert.*
+
+class MarkdownRendererTest {
+
+    @Test
+    fun `test render with empty tokens list`() {
+        val markdown = "Hello World"
+        val tokens = emptyList<MarkdownToken>()
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Hello World", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render with no tokens`() {
+        val markdown = "Plain text without markdown"
+        val tokens = emptyList<MarkdownToken>()
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Plain text without markdown", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render bold token`() {
+        val markdown = "This is **bold** text"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("This is bold text", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render italic token`() {
+        val markdown = "This is *italic* text"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("This is italic text", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val italicStyle = result.spanStyles[0]
+        assertEquals(FontStyle.Italic, italicStyle.item.fontStyle)
+        assertTrue(italicStyle.start >= 0)
+        assertTrue(italicStyle.end > italicStyle.start)
+    }
+
+    @Test
+    fun `test render inline code token`() {
+        val markdown = "Use `println()` function"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Use println() function", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val codeStyle = result.spanStyles[0]
+        assertEquals(Color.LightGray, codeStyle.item.background)
+        assertEquals(14.sp, codeStyle.item.fontSize)
+        assertEquals(FontFamily.Monospace, codeStyle.item.fontFamily)
+        assertTrue(codeStyle.start >= 0)
+        assertTrue(codeStyle.end > codeStyle.start)
+    }
+
+    @Test
+    fun `test render code block token`() {
+        val markdown = "```\nfun test() {}\n```"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertTrue(result.text.contains("fun test() {}"))
+        assertEquals(1, result.spanStyles.size)
+        
+        val codeBlockStyle = result.spanStyles[0]
+        assertEquals(Color(0xFFEFEFEF), codeBlockStyle.item.background)
+        assertEquals(Color(0xFF333333), codeBlockStyle.item.color)
+        assertEquals(16.sp, codeBlockStyle.item.fontSize)
+        assertEquals(FontFamily.Monospace, codeBlockStyle.item.fontFamily)
+        assertTrue(codeBlockStyle.start >= 0)
+        assertTrue(codeBlockStyle.end > codeBlockStyle.start)
+    }
+
+    @Test
+    fun `test render link token`() {
+        val markdown = "[Click here](https://example.com)"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Click here", result.text)
+        assertEquals(1, result.spanStyles.size)
+        assertEquals(1, result.getStringAnnotations("URL", 0, result.length).size)
+        
+        val linkStyle = result.spanStyles[0]
+        assertEquals(Color.Blue, linkStyle.item.color)
+        assertEquals(TextDecoration.Underline, linkStyle.item.textDecoration)
+        assertTrue(linkStyle.start >= 0)
+        assertTrue(linkStyle.end > linkStyle.start)
+        
+        val urlAnnotation = result.getStringAnnotations("URL", 0, result.length)[0]
+        assertEquals("https://example.com", urlAnnotation.item)
+        assertTrue(urlAnnotation.start >= 0)
+        assertTrue(urlAnnotation.end > urlAnnotation.start)
+    }
+
+    @Test
+    fun `test render heading token level 1`() {
+        val markdown = "# Main Heading"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Main Heading", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val headingStyle = result.spanStyles[0]
+        assertEquals(26.sp, headingStyle.item.fontSize)
+        assertEquals(FontWeight.Bold, headingStyle.item.fontWeight)
+        assertEquals(Color(0xFFA75CF2), headingStyle.item.color)
+        assertTrue(headingStyle.start >= 0)
+        assertTrue(headingStyle.end > headingStyle.start)
+    }
+
+    @Test
+    fun `test render heading token level 2`() {
+        val markdown = "## Sub Heading"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Sub Heading", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val headingStyle = result.spanStyles[0]
+        assertEquals(22.sp, headingStyle.item.fontSize)
+        assertEquals(FontWeight.Bold, headingStyle.item.fontWeight)
+        assertEquals(Color(0xFF48D883), headingStyle.item.color)
+        assertTrue(headingStyle.start >= 0)
+        assertTrue(headingStyle.end > headingStyle.start)
+    }
+
+    @Test
+    fun `test render list token`() {
+        val markdown = "- List item"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("• List item\n", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render blockquote token`() {
+        val markdown = "> This is a quote"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("This is a quote\n", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val quoteStyle = result.spanStyles[0]
+        assertEquals(Color(0xFFE0E0E0), quoteStyle.item.background)
+        assertEquals(FontStyle.Italic, quoteStyle.item.fontStyle)
+        assertTrue(quoteStyle.start >= 0)
+        assertTrue(quoteStyle.end > quoteStyle.start)
+    }
+
+    @Test
+    fun `test render multiple tokens in sequence`() {
+        val markdown = "**Bold** and *italic* text"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Bold and italic text", result.text)
+        assertEquals(2, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+        
+        val italicStyle = result.spanStyles[1]
+        assertEquals(FontStyle.Italic, italicStyle.item.fontStyle)
+        assertTrue(italicStyle.start >= 0)
+        assertTrue(italicStyle.end > italicStyle.start)
+    }
+
+    @Test
+    fun `test render tokens with gaps`() {
+        val markdown = "Start **middle** end"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Start middle end", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render overlapping tokens`() {
+        val markdown = "**Bold *italic* text**"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        // The tokenizer doesn't handle nested markdown, so it will only parse the outer bold
+        assertTrue(result.text.contains("Bold"))
+        assertTrue(result.text.contains("italic"))
+        assertTrue(result.text.contains("text"))
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render complex mixed content`() {
+        val markdown = "# Title\n\nThis is **bold** and *italic* text.\n\n[Link](https://example.com)\n\n- List item\n\n> Quote here\n\n`inline code`"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        // Verify the content is rendered (exact text may vary due to tokenizer behavior)
+        assertTrue(result.text.contains("Title"))
+        assertTrue(result.text.contains("bold"))
+        assertTrue(result.text.contains("italic"))
+        assertTrue(result.text.contains("Link"))
+        assertTrue(result.text.contains("List item"))
+        assertTrue(result.text.contains("Quote here"))
+        assertTrue(result.text.contains("inline code"))
+        
+        // Should have multiple span styles
+        assertTrue(result.spanStyles.size > 0)
+        
+        // Should have URL annotation for the link
+        val urlAnnotations = result.getStringAnnotations("URL", 0, result.length)
+        assertTrue(urlAnnotations.isNotEmpty())
+        assertEquals("https://example.com", urlAnnotations[0].item)
+    }
+
+    @Test
+    fun `test render with tokens out of order`() {
+        val markdown = "Text with **bold** and *italic*"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Text with bold and italic", result.text)
+        assertEquals(2, result.spanStyles.size)
+        
+        // Should still render correctly despite out-of-order tokens
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+        
+        val italicStyle = result.spanStyles[1]
+        assertEquals(FontStyle.Italic, italicStyle.item.fontStyle)
+        assertTrue(italicStyle.start >= 0)
+        assertTrue(italicStyle.end > italicStyle.start)
+    }
+
+    @Test
+    fun `test render with token starting at beginning`() {
+        val markdown = "**Bold** text"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Bold text", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render with token ending at end`() {
+        val markdown = "Text **bold**"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Text bold", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render with empty token groups`() {
+        val markdown = "Text with **bold**"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Text with bold", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertTrue(boldStyle.start >= 0)
+        assertTrue(boldStyle.end > boldStyle.start)
+    }
+
+    @Test
+    fun `test render with multiple empty tokens`() {
+        val markdown = "Hello World"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("Hello World", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render empty markdown string`() {
+        val markdown = ""
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render markdown with only whitespace`() {
+        val markdown = "   \n\t  "
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("   \n\t  ", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render single character bold`() {
+        val markdown = "**a**"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("a", result.text)
+        assertEquals(1, result.spanStyles.size)
+        
+        val boldStyle = result.spanStyles[0]
+        assertEquals(FontWeight.Bold, boldStyle.item.fontWeight)
+        assertEquals(0, boldStyle.start)
+        assertEquals(1, boldStyle.end)
+    }
+
+    @Test
+    fun `test render markdown with no valid tokens`() {
+        val markdown = "This is just plain text with no markdown"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+        
+        assertEquals("This is just plain text with no markdown", result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun `test render with malformed markdown`() {
+        val markdown = "**unclosed bold *unclosed italic"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        
+        val result = MarkdownRenderer.render(markdown, tokens)
+
+        // Should still render what can be parsed
+        assertTrue(result.text.contains("unclosed bold"))
+        assertTrue(result.text.contains("unclosed italic"))
+        assertTrue(result.spanStyles.size > 0)
+    }
+}

--- a/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/MainScreen.kt
+++ b/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/MainScreen.kt
@@ -39,16 +39,19 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.conciergetestapp.ui.ChatScreen
+import com.adobe.marketing.mobile.conciergetestapp.ui.MarkdownDemoScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreenWrapper() {
     val showChat = remember { mutableStateOf(false) }
+    val showMarkdownDemo = remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Main screen with chat button
         MainScreen(
-            onStartChat = { showChat.value = true }
+            onStartChat = { showChat.value = true },
+            onShowMarkdownDemo = { showMarkdownDemo.value = true }
         )
 
         // Chat modal sheet
@@ -68,12 +71,31 @@ fun MainScreenWrapper() {
                 )
             }
         }
+
+        // Markdown demo modal sheet
+        if (showMarkdownDemo.value) {
+            ModalBottomSheet(
+                onDismissRequest = { showMarkdownDemo.value = false },
+                sheetState = rememberModalBottomSheetState(
+                    skipPartiallyExpanded = true
+                ),
+                containerColor = Color.White,
+                dragHandle = null,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                MarkdownDemoScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    onClose = { showMarkdownDemo.value = false }
+                )
+            }
+        }
     }
 }
 
 @Composable
 fun MainScreen(
-    onStartChat: () -> Unit
+    onStartChat: () -> Unit,
+    onShowMarkdownDemo: () -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -120,6 +142,43 @@ fun MainScreen(
                     fontSize = 24.sp
                 )
             }
+            
+            // Chat button label
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Start Chat",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color(0xFF666666)
+            )
+            
+            Spacer(modifier = Modifier.height(24.dp))
+            
+            // Markdown demo button
+            Button(
+                onClick = { onShowMarkdownDemo() },
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF4CAF50)
+                ),
+                shape = RoundedCornerShape(40.dp)
+            ) {
+                Text(
+                    text = "📝",
+                    fontSize = 24.sp
+                )
+            }
+            
+            // Markdown demo button label
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Markdown Demo",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color(0xFF666666)
+            )
         }
     }
 }

--- a/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/ui/ChatScreen.kt
+++ b/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/ui/ChatScreen.kt
@@ -12,7 +12,6 @@
 
 package com.adobe.marketing.mobile.conciergetestapp.ui
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember

--- a/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/ui/MarkdownDemoScreen.kt
+++ b/code/testapp/src/main/kotlin/com/adobe/marketing/mobile/conciergetestapp/ui/MarkdownDemoScreen.kt
@@ -1,0 +1,72 @@
+package com.adobe.marketing.mobile.conciergetestapp.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adobe.marketing.mobile.concierge.ui.components.messages.ConciergeResponse
+
+/**
+ * Demo screen showcasing the markdown parser functionality
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarkdownDemoScreen(
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit
+) {
+    val sampleMarkdown = "Looking for a beach trip for your summer getaway? Here are some fantastic beach destinations to consider:\n\n1. **[Miami](https://www.southwestvacations.com/destinations/united-states/miami-vacation-packages-mf1)** - Known for its vibrant nightlife and beautiful sandy shores, Miami is perfect for those who want to soak up the sun and enjoy a lively atmosphere.\n\n2. **[Fort Lauderdale](https://www.southwestvacations.com/destinations/united-states/fort-lauderdale-vacation-packages-fll)** - Famous for its boating canals and stunning beaches, Fort Lauderdale offers a relaxed beach vibe along with plenty of water activities.\n\n3. **[Destin](https://www.southwestvacations.com/destinations/united-states/south-walton-beach-destin-vacation-packages-ec1)** - Renowned for its emerald waters and sugar-white sand beaches, Destin is a great choice for families and beach lovers looking for fun in the sun.\n\n4. **[Pensacola](https://www.southwestvacations.com/destinations/united-states/pensacola-vacation-packages-pns)** - With its rich history and beautiful beaches, Pensacola provides a mix of cultural attractions and outdoor activities, making it a diverse getaway option.\n\n5. **[Naples](https://www.southwestvacations.com/destinations/united-states/naples-vacation-packages-na3/)** - Enjoy over ten miles of stunning white sand beaches and clear Gulf waters, along with a vibrant dining scene and family-friendly activities.\n\nEach of these destinations offers a unique beach experience, so you can find the perfect spot for your summer escape! If you'd like more information on any of these locations, just let me know!"
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Markdown Parser Demo",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold
+            )
+            
+            Button(
+                onClick = onClose,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Text("Close")
+            }
+        }
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        // Markdown content
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                ConciergeResponse(text = sampleMarkdown)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a markdown parser to convert then render brand concierge markdown responses as `AnnotatedString`s. The concierge responses now use a `ConciergeResponse` composable which display the AnnotatedString created from the markdown content. A section has also been added in the test app which displays a sample concierge markdown response using this new composable:
<img width="200" height="400" alt="Screenshot_1756230791" src="https://github.com/user-attachments/assets/b9bb119b-20f2-4c65-b9a0-152e95ccfb04" />

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
