### PR TITLE
respect blank lines when tokenizing lists

### DIFF
--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizer.kt
@@ -113,15 +113,22 @@ internal object MarkdownTokenizer {
             
             // Find the end of this list item (start of next list item or end of string)
             val contentEnd = if (i < matches.size - 1) {
-                // Content ends at the start of the next list item
-                // Find the position just before the next list marker, trimming any whitespace/newlines
                 val nextListStart = matches[i + 1].range.first
-                // Back up to find the last non-whitespace character before the next list item
-                var actualEnd = nextListStart
-                while (actualEnd > contentStart && markdown[actualEnd - 1].isWhitespace()) {
-                    actualEnd--
+                // A blank line ends the current list item's content, even if the next
+                // list marker appears later. This ensures that non-list text between
+                // two list sections is not absorbed into the preceding item's content.
+                val contentSubstring = markdown.substring(contentStart, nextListStart)
+                val blankLineIndex = contentSubstring.indexOf("\n\n")
+                if (blankLineIndex != -1) {
+                    contentStart + blankLineIndex
+                } else {
+                    // Back up to find the last non-whitespace character before the next list item
+                    var actualEnd = nextListStart
+                    while (actualEnd > contentStart && markdown[actualEnd - 1].isWhitespace()) {
+                        actualEnd--
+                    }
+                    actualEnd
                 }
-                actualEnd
             } else {
                 // This is the last list item
                 // Check if there's content after this list item (separated by blank lines)
@@ -248,9 +255,9 @@ internal object MarkdownTokenizer {
         // Check content between previous item and current line
         if (lineStart <= prevContentEnd) return false
         
-        val contentBetween = markdown.substring(prevContentEnd, lineStart)
         // Blank line = 2+ newlines
-        return contentBetween.count { it == '\n' } >= 2
+        val contentBetween = markdown.substring(prevContentEnd, lineStart)
+        return contentBetween.contains("\n\n")
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizerTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/markdown/MarkdownTokenizerTest.kt
@@ -410,6 +410,34 @@ Trailing text""".trimIndent()
     }
     
     @Test
+    fun `test tokenize bullets separated by non-list text do not bleed into each other`() {
+        val markdown = """1) First Section Header
+• Bullet one
+• Bullet two
+
+2) Second Section Header
+• Bullet three
+• Bullet four""".trimIndent()
+
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+        val listTokens = tokens.filter { it.type == TokenType.LIST }
+
+        assertEquals(4, listTokens.size)
+        assertEquals("Bullet two", listTokens[1].groups[0])
+        assertEquals("Bullet three", listTokens[2].groups[0])
+    }
+
+    @Test
+    fun `test hasPrecedingBlankLine does not trigger for multi-line items without blank line`() {
+        val markdown = "- Item A\n  continuation line\n  - Nested item"
+        val tokens = MarkdownTokenizer.tokenize(markdown)
+
+        val listTokens = tokens.filter { it.type == TokenType.LIST }
+        assertEquals(2, listTokens.size)
+        assertEquals(1, listTokens[1].indentationLevel)
+    }
+
+    @Test
     fun `test tokenize bold link`() {
         val markdown = "**[Adobe Premiere Pro](https://www.adobe.com/premiere)**"
         val tokens = MarkdownTokenizer.tokenize(markdown)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Detect blank lines when computing a list item's content end so that non-list text between list sections doesn't get absorbed into the previous item.
- Added unit tests to cover bullets separated by non-list text and multi-line list items without blank lines to prevent bleeding and preserve nesting/indentation.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Issue found when manually testing concierge responses containing list content. I verified that the affected markdown content is now rendered correctly.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
