### PR TITLE
Add CTA buttons with theming and ordered multimodal support

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -19,6 +19,8 @@ This document provides a comprehensive reference for all styling properties supp
   - [Typography](#typography)
   - [Colors](#colors)
   - [Layout](#layout)
+  - [Colors - CTA Button](#colors---cta-button)
+  - [Layout - CTA Button](#layout---cta-button)
 - [Implementation Status](#implementation-status)
 
 ---
@@ -565,6 +567,14 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 |--------------|-----------------|------|---------|-------------|
 | `--disclaimer-color` | `colors.disclaimer` | `String` | `"#757575"` | Disclaimer text color (hex) |
 
+### Colors - CTA Button
+
+| CSS Variable | Kotlin Property | Type | Default | Description |
+|--------------|-----------------|------|---------|-------------|
+| `--cta-button-background-color` | `colors.ctaButton.background` | `String` | `"systemGray6"` | CTA button background color (hex) |
+| `--cta-button-text-color` | `colors.ctaButton.text` | `String` | `"primary"` | CTA button label text color (hex) |
+| `--cta-button-icon-color` | `colors.ctaButton.iconColor` | `String` | `"primary"` | CTA button icon color (hex) |
+
 ### Colors - Extended Product Cards
 
 Used when `behavior.productCard.cardStyle` is `"productDetail"`.
@@ -651,6 +661,17 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
 | CSS Variable | Kotlin Property | Type | Default | Description |
 |--------------|-----------------|------|---------|-------------|
 | `--button-height-s` | `cssLayout.buttonHeightSmall` | `Double` | `30.0` | Small button height (dp) |
+
+### Layout - CTA Button
+
+| CSS Variable | Kotlin Property | Type | Default | Description |
+|--------------|-----------------|------|---------|-------------|
+| `--cta-button-border-radius` | `layout.ctaButtonBorderRadius` | `Double` | `99.0` | CTA button corner radius (dp) |
+| `--cta-button-horizontal-padding` | `layout.ctaButtonHorizontalPadding` | `Double` | `16.0` | CTA button horizontal padding (dp) |
+| `--cta-button-vertical-padding` | `layout.ctaButtonVerticalPadding` | `Double` | `12.0` | CTA button vertical padding (dp) |
+| `--cta-button-font-size` | `layout.ctaButtonFontSize` | `Double` | `14.0` | CTA button label font size (sp) |
+| `--cta-button-font-weight` | `layout.ctaButtonFontWeight` | `Int` | `400` | CTA button label font weight |
+| `--cta-button-icon-size` | `layout.ctaButtonIconSize` | `Double` | `16.0` | CTA button icon size (dp) |
 
 ### Layout - Feedback
 
@@ -1049,6 +1070,9 @@ These colors are used internally by composables but cannot be customized in them
 | `--feedback-icon-btn-background` | ✅ | Thumbs up/down button background | `FeedbackComponents` |
 | `--feedback-icon-btn-hover-background` | ⚠️ | Parsed but no hover states on Android | - |
 | `--disclaimer-color` | ✅ | Disclaimer text color | `ConciergeDisclaimer` (DisclaimerStyle) |
+| `--cta-button-background-color` | ✅ | CTA button background color | `CtaButton` |
+| `--cta-button-text-color` | ✅ | CTA button label text color | `CtaButton` |
+| `--cta-button-icon-color` | ✅ | CTA button icon color | `CtaButton` |
 | `--product-card-outline-color` | ✅ | Extended product card border color | `ExtendedProductCard` |
 | `--product-card-background-color` | ✅ | Extended product card background | `ExtendedProductCard` |
 | `--product-card-title-color` | ✅ | Extended product card title color | `ExtendedProductCard` |
@@ -1104,6 +1128,12 @@ Note: The feedback dialog checkbox uses `--color-primary` for the check box fill
 | `--product-card-carousel-horizontal-padding` | ✅ | Carousel horizontal padding | `ProductCarousel` |
 | `--product-card-carousel-spacing` | ✅ | Spacing between carousel cards | `ProductCarousel` |
 | `--button-height-s` | ⚠️ | Parsed but not used in composables | - |
+| `--cta-button-border-radius` | ✅ | CTA button corner radius | `CtaButton` |
+| `--cta-button-horizontal-padding` | ✅ | CTA button horizontal padding | `CtaButton` |
+| `--cta-button-vertical-padding` | ✅ | CTA button vertical padding | `CtaButton` |
+| `--cta-button-font-size` | ✅ | CTA button label font size | `CtaButton` |
+| `--cta-button-font-weight` | ✅ | CTA button label font weight | `CtaButton` |
+| `--cta-button-icon-size` | ✅ | CTA button icon size | `CtaButton` |
 | `--feedback-container-gap` | ⚠️ | Parsed but not used in composables | - |
 | `--feedback-icon-btn-size-desktop` | ⚠️ | Parsed but not used in composables | - |
 | `--citations-text-font-weight` | ⚠️ | Parsed but not used in composables | - |

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
@@ -67,6 +67,9 @@ internal object ConversationResponseParser {
     private const val FIELD_PRODUCT_PRICE = "productPrice"
     private const val FIELD_PRODUCT_WAS_PRICE = "productWasPrice"
     private const val FIELD_PRODUCT_BADGE = "productBadge"
+    private const val FIELD_CTA_BUTTON = "ctaButton"
+    private const val FIELD_CTA_BUTTON_LABEL = "label"
+    private const val FIELD_CTA_BUTTON_URL = "url"
 
     /**
      * Parses a JSON string from an SSE data event and extracts conversation messages.
@@ -143,6 +146,7 @@ internal object ConversationResponseParser {
 
         val multimodalElements = extractMultimodalElements(response)
         val sources = extractSources(response)
+        val ctaButton = extractCtaButton(response)
 
         return ParsedConversationMessage(
             messageContent = message,
@@ -151,7 +155,8 @@ internal object ConversationResponseParser {
             interactionId = interactionId,
             promptSuggestions = promptSuggestions,
             multimodalElements = multimodalElements,
-            sources = sources
+            sources = sources,
+            ctaButton = ctaButton
         )
     }
 
@@ -312,6 +317,19 @@ internal object ConversationResponseParser {
         val primaryVal = DataReader.optString(primary, field, null)?.takeIf { it.isNotEmpty() }
         if (primaryVal != null) return primaryVal
         return DataReader.optString(fallback, field, null)?.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Extracts a CTA button from the response map, if present.
+     */
+    private fun extractCtaButton(response: Map<String, Any?>): CtaButton? {
+        val ctaMap = DataReader.optTypedMap(Any::class.java, response, FIELD_CTA_BUTTON, null)
+            ?: return null
+        val label = DataReader.optString(ctaMap, FIELD_CTA_BUTTON_LABEL, null)?.takeIf { it.isNotEmpty() }
+            ?: return null
+        val url = DataReader.optString(ctaMap, FIELD_CTA_BUTTON_URL, null)?.takeIf { it.isNotEmpty() }
+            ?: return null
+        return CtaButton(label = label, url = url)
     }
 
     /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
@@ -67,9 +67,7 @@ internal object ConversationResponseParser {
     private const val FIELD_PRODUCT_PRICE = "productPrice"
     private const val FIELD_PRODUCT_WAS_PRICE = "productWasPrice"
     private const val FIELD_PRODUCT_BADGE = "productBadge"
-    private const val FIELD_ELEMENT_TYPE = "elementType"
     private const val ELEMENT_TYPE_CTA_BUTTON = "ctaButton"
-    private const val FIELD_LABEL = "label"
 
     /**
      * Parses a JSON string from an SSE data event and extracts conversation messages.
@@ -180,7 +178,7 @@ internal object ConversationResponseParser {
 
         val items = mutableListOf<ParsedMultimodalItem>()
         elementsList.forEachIndexed { i, elementMap ->
-            val elementType = DataReader.optString(elementMap, FIELD_ELEMENT_TYPE, "")
+            val elementType = DataReader.optString(elementMap, FIELD_TYPE, "")
             if (elementType == ELEMENT_TYPE_CTA_BUTTON) {
                 val ctaButton = parseCtaButton(elementMap)
                 if (ctaButton != null) {
@@ -204,14 +202,14 @@ internal object ConversationResponseParser {
 
     /**
      * Parses a CTA button from an element map.
-     * Reads label and url from entity_info, falling back to root element fields.
-     * Returns null if label or url is empty.
+     * Reads label and url from entity_info.primary.text and entity_info.primary.url.
+     * Returns null if label or url is missing.
      */
     private fun parseCtaButton(elementMap: Map<String, Any?>): CtaButton? {
         val entityInfo = DataReader.optTypedMap(Any::class.java, elementMap, FIELD_ENTITY_INFO, null)
-        val label = optStringFallback(entityInfo, elementMap, FIELD_LABEL)
-            ?: optStringFallback(entityInfo, elementMap, FIELD_BUTTON_TEXT)
-        val url = optStringFallback(entityInfo, elementMap, FIELD_BUTTON_URL)
+        val primaryAction = entityInfo?.let { DataReader.optTypedMap(Any::class.java, it, FIELD_PRIMARY, null) }
+        val label = DataReader.optString(primaryAction, FIELD_BUTTON_TEXT, null)?.takeIf { it.isNotEmpty() }
+        val url = DataReader.optString(primaryAction, FIELD_BUTTON_URL, null)?.takeIf { it.isNotEmpty() }
         if (label.isNullOrEmpty() || url.isNullOrEmpty()) return null
         return CtaButton(label = label, url = url)
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
@@ -67,7 +67,9 @@ internal object ConversationResponseParser {
     private const val FIELD_PRODUCT_PRICE = "productPrice"
     private const val FIELD_PRODUCT_WAS_PRICE = "productWasPrice"
     private const val FIELD_PRODUCT_BADGE = "productBadge"
-    private const val CTA_BUTTON_TYPE = "ctaButton"
+    private const val FIELD_ELEMENT_TYPE = "elementType"
+    private const val ELEMENT_TYPE_CTA_BUTTON = "ctaButton"
+    private const val FIELD_LABEL = "label"
 
     /**
      * Parses a JSON string from an SSE data event and extracts conversation messages.
@@ -142,9 +144,9 @@ internal object ConversationResponseParser {
         val promptSuggestions = (DataReader.optTypedList(String::class.java, response, FIELD_PROMPT_SUGGESTIONS, null)
             ?: emptyList()).filter { it.isNotEmpty() }
 
-        val multimodalElements = extractMultimodalElements(response)
+        val orderedElements = extractOrderedElements(response)
+        val multimodalElements = orderedElements.filterIsInstance<ParsedMultimodalItem.Card>().map { it.element }
         val sources = extractSources(response)
-        val ctaButton = extractCtaButtonFromElements(response)
 
         return ParsedConversationMessage(
             messageContent = message,
@@ -153,30 +155,20 @@ internal object ConversationResponseParser {
             interactionId = interactionId,
             promptSuggestions = promptSuggestions,
             multimodalElements = multimodalElements,
-            sources = sources,
-            ctaButton = ctaButton
+            orderedElements = orderedElements,
+            sources = sources
         )
     }
 
     /**
-     * Extracts multimodal elements from the response map.
-     * Ignores array-format multimodalElements; expects object with elements list.
+     * Extracts ordered elements from the response, preserving original array position.
+     * Each element is parsed as either a [ParsedMultimodalItem.Cta] (for ctaButton elements)
+     * or a [ParsedMultimodalItem.Card] (for all other element types).
      */
-    private fun extractMultimodalElements(response: Map<String, Any?>): List<MultimodalElement> {
-        val multimodalRaw = response[FIELD_MULTIMODAL_ELEMENTS]
-        if (multimodalRaw == null) {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "No multimodalElements found in response.")
-            return emptyList()
-        }
-        if (multimodalRaw is List<*>) {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "multimodalElements array format; ignoring.")
-            return emptyList()
-        }
-        val multimodalMap = multimodalRaw as? Map<*, *>
-        if (multimodalMap == null) {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "No multimodalElements found in response.")
-            return emptyList()
-        }
+    private fun extractOrderedElements(response: Map<String, Any?>): List<ParsedMultimodalItem> {
+        val multimodalRaw = response[FIELD_MULTIMODAL_ELEMENTS] ?: return emptyList()
+        if (multimodalRaw is List<*>) return emptyList()
+        val multimodalMap = multimodalRaw as? Map<*, *> ?: return emptyList()
 
         @Suppress("UNCHECKED_CAST")
         val elementsList = DataReader.optTypedListOfMap(
@@ -184,42 +176,44 @@ internal object ConversationResponseParser {
             multimodalMap as Map<String, Any?>,
             FIELD_ELEMENTS,
             null
-        )
-        if (elementsList == null) {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "No elements array found in multimodalElements.")
-            return emptyList()
-        }
+        ) ?: return emptyList()
 
-        val elements = mutableListOf<MultimodalElement>()
+        val items = mutableListOf<ParsedMultimodalItem>()
         elementsList.forEachIndexed { i, elementMap ->
-            // Skip ctaButton elements — they are parsed separately
-            val type = DataReader.optString(elementMap, FIELD_TYPE, null)
-            if (type == CTA_BUTTON_TYPE) return@forEachIndexed
-
-            val element = parseMultimodalElement(elementMap)
-            if (element != null) {
-                elements.add(element)
-                Log.debug(
-                    ConciergeConstants.EXTENSION_NAME,
-                    TAG,
-                    "Parsed multimodal element ${i + 1}: id=${element.id}, title=${element.title ?: "N/A"}."
-                )
+            val elementType = DataReader.optString(elementMap, FIELD_ELEMENT_TYPE, "")
+            if (elementType == ELEMENT_TYPE_CTA_BUTTON) {
+                val ctaButton = parseCtaButton(elementMap)
+                if (ctaButton != null) {
+                    items.add(ParsedMultimodalItem.Cta(ctaButton))
+                    Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "Parsed CTA button ${i + 1}: label=${ctaButton.label}")
+                } else {
+                    Log.warning(ConciergeConstants.EXTENSION_NAME, TAG, "Failed to parse CTA button element ${i + 1}.")
+                }
             } else {
-                Log.warning(
-                    ConciergeConstants.EXTENSION_NAME,
-                    TAG,
-                    "Failed to parse multimodal element ${i + 1} from JSON."
-                )
+                val element = parseMultimodalElement(elementMap)
+                if (element != null) {
+                    items.add(ParsedMultimodalItem.Card(element))
+                    Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "Parsed card element ${i + 1}: id=${element.id}")
+                } else {
+                    Log.warning(ConciergeConstants.EXTENSION_NAME, TAG, "Failed to parse card element ${i + 1}.")
+                }
             }
         }
+        return items
+    }
 
-        if (elements.isNotEmpty()) {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "Successfully parsed ${elements.size} multimodal elements from response.")
-        } else {
-            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "No valid multimodal elements found in elements array.")
-        }
-
-        return elements
+    /**
+     * Parses a CTA button from an element map.
+     * Reads label and url from entity_info, falling back to root element fields.
+     * Returns null if label or url is empty.
+     */
+    private fun parseCtaButton(elementMap: Map<String, Any?>): CtaButton? {
+        val entityInfo = DataReader.optTypedMap(Any::class.java, elementMap, FIELD_ENTITY_INFO, null)
+        val label = optStringFallback(entityInfo, elementMap, FIELD_LABEL)
+            ?: optStringFallback(entityInfo, elementMap, FIELD_BUTTON_TEXT)
+        val url = optStringFallback(entityInfo, elementMap, FIELD_BUTTON_URL)
+        if (label.isNullOrEmpty() || url.isNullOrEmpty()) return null
+        return CtaButton(label = label, url = url)
     }
 
     /**
@@ -319,37 +313,6 @@ internal object ConversationResponseParser {
         val primaryVal = DataReader.optString(primary, field, null)?.takeIf { it.isNotEmpty() }
         if (primaryVal != null) return primaryVal
         return DataReader.optString(fallback, field, null)?.takeIf { it.isNotEmpty() }
-    }
-
-    /**
-     * Finds the first element with type "ctaButton" in multimodalElements.elements and
-     * extracts its label and URL from entity_info.primary.
-     */
-    private fun extractCtaButtonFromElements(response: Map<String, Any?>): CtaButton? {
-        val multimodalRaw = response[FIELD_MULTIMODAL_ELEMENTS] as? Map<*, *> ?: return null
-
-        @Suppress("UNCHECKED_CAST")
-        val elementsList = DataReader.optTypedListOfMap(
-            Any::class.java,
-            multimodalRaw as Map<String, Any?>,
-            FIELD_ELEMENTS,
-            null
-        ) ?: return null
-
-        val ctaElementMap = elementsList.firstOrNull { elementMap ->
-            DataReader.optString(elementMap, FIELD_TYPE, null) == CTA_BUTTON_TYPE
-        } ?: return null
-
-        val entityInfo = DataReader.optTypedMap(Any::class.java, ctaElementMap, FIELD_ENTITY_INFO, null)
-        val primary = DataReader.optTypedMap(Any::class.java, entityInfo ?: ctaElementMap, FIELD_PRIMARY, null)
-            ?: return null
-
-        val label = DataReader.optString(primary, FIELD_BUTTON_TEXT, null)?.takeIf { it.isNotEmpty() }
-            ?: return null
-        val url = DataReader.optString(primary, FIELD_BUTTON_URL, null)?.takeIf { it.isNotEmpty() }
-            ?: return null
-
-        return CtaButton(label = label, url = url)
     }
 
     /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParser.kt
@@ -67,9 +67,7 @@ internal object ConversationResponseParser {
     private const val FIELD_PRODUCT_PRICE = "productPrice"
     private const val FIELD_PRODUCT_WAS_PRICE = "productWasPrice"
     private const val FIELD_PRODUCT_BADGE = "productBadge"
-    private const val FIELD_CTA_BUTTON = "ctaButton"
-    private const val FIELD_CTA_BUTTON_LABEL = "label"
-    private const val FIELD_CTA_BUTTON_URL = "url"
+    private const val CTA_BUTTON_TYPE = "ctaButton"
 
     /**
      * Parses a JSON string from an SSE data event and extracts conversation messages.
@@ -146,7 +144,7 @@ internal object ConversationResponseParser {
 
         val multimodalElements = extractMultimodalElements(response)
         val sources = extractSources(response)
-        val ctaButton = extractCtaButton(response)
+        val ctaButton = extractCtaButtonFromElements(response)
 
         return ParsedConversationMessage(
             messageContent = message,
@@ -194,6 +192,10 @@ internal object ConversationResponseParser {
 
         val elements = mutableListOf<MultimodalElement>()
         elementsList.forEachIndexed { i, elementMap ->
+            // Skip ctaButton elements — they are parsed separately
+            val type = DataReader.optString(elementMap, FIELD_TYPE, null)
+            if (type == CTA_BUTTON_TYPE) return@forEachIndexed
+
             val element = parseMultimodalElement(elementMap)
             if (element != null) {
                 elements.add(element)
@@ -320,15 +322,33 @@ internal object ConversationResponseParser {
     }
 
     /**
-     * Extracts a CTA button from the response map, if present.
+     * Finds the first element with type "ctaButton" in multimodalElements.elements and
+     * extracts its label and URL from entity_info.primary.
      */
-    private fun extractCtaButton(response: Map<String, Any?>): CtaButton? {
-        val ctaMap = DataReader.optTypedMap(Any::class.java, response, FIELD_CTA_BUTTON, null)
+    private fun extractCtaButtonFromElements(response: Map<String, Any?>): CtaButton? {
+        val multimodalRaw = response[FIELD_MULTIMODAL_ELEMENTS] as? Map<*, *> ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val elementsList = DataReader.optTypedListOfMap(
+            Any::class.java,
+            multimodalRaw as Map<String, Any?>,
+            FIELD_ELEMENTS,
+            null
+        ) ?: return null
+
+        val ctaElementMap = elementsList.firstOrNull { elementMap ->
+            DataReader.optString(elementMap, FIELD_TYPE, null) == CTA_BUTTON_TYPE
+        } ?: return null
+
+        val entityInfo = DataReader.optTypedMap(Any::class.java, ctaElementMap, FIELD_ENTITY_INFO, null)
+        val primary = DataReader.optTypedMap(Any::class.java, entityInfo ?: ctaElementMap, FIELD_PRIMARY, null)
             ?: return null
-        val label = DataReader.optString(ctaMap, FIELD_CTA_BUTTON_LABEL, null)?.takeIf { it.isNotEmpty() }
+
+        val label = DataReader.optString(primary, FIELD_BUTTON_TEXT, null)?.takeIf { it.isNotEmpty() }
             ?: return null
-        val url = DataReader.optString(ctaMap, FIELD_CTA_BUTTON_URL, null)?.takeIf { it.isNotEmpty() }
+        val url = DataReader.optString(primary, FIELD_BUTTON_URL, null)?.takeIf { it.isNotEmpty() }
             ?: return null
+
         return CtaButton(label = label, url = url)
     }
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponse.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponse.kt
@@ -55,7 +55,17 @@ internal data class ConversationRequest(
 internal data class ConversationResponse(
     val message: String,
     val multimodalElements: List<MultimodalElement> = emptyList(),
-    val promptSuggestions: List<String> = emptyList()
+    val promptSuggestions: List<String> = emptyList(),
+    val ctaButton: CtaButton? = null
+)
+
+/**
+ * Represents a CTA button (e.g., "Chat with a teammate")
+ * that appears below a bot message.
+ */
+internal data class CtaButton(
+    val label: String,
+    val url: String
 )
 
 /**
@@ -118,5 +128,6 @@ internal data class ParsedConversationMessage(
     val interactionId: String? = null,
     val promptSuggestions: List<String> = emptyList(),
     val multimodalElements: List<MultimodalElement> = emptyList(),
-    val sources: List<Citation> = emptyList()
+    val sources: List<Citation> = emptyList(),
+    val ctaButton: CtaButton? = null
 )

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponse.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponse.kt
@@ -60,13 +60,21 @@ internal data class ConversationResponse(
 )
 
 /**
- * Represents a CTA button (e.g., "Chat with a teammate")
- * that appears below a bot message.
+ * Represents a CTA button that appears as a standalone action below a bot message.
  */
 internal data class CtaButton(
     val label: String,
     val url: String
 )
+
+/**
+ * Represents an ordered element from a multimodal API response.
+ * Preserves the original array position so CTAs and cards can be interleaved correctly.
+ */
+internal sealed class ParsedMultimodalItem {
+    data class Card(val element: MultimodalElement) : ParsedMultimodalItem()
+    data class Cta(val button: CtaButton) : ParsedMultimodalItem()
+}
 
 /**
  * Multimodal elements for rich content
@@ -128,6 +136,6 @@ internal data class ParsedConversationMessage(
     val interactionId: String? = null,
     val promptSuggestions: List<String> = emptyList(),
     val multimodalElements: List<MultimodalElement> = emptyList(),
-    val sources: List<Citation> = emptyList(),
-    val ctaButton: CtaButton? = null
+    val orderedElements: List<ParsedMultimodalItem> = emptyList(),
+    val sources: List<Citation> = emptyList()
 )

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChat.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChat.kt
@@ -332,6 +332,7 @@ internal fun ConciergeChat(
                     onImageClick = { element -> onEvent(ProductImageClick(element)) },
                     onSuggestionClick = { suggestion -> onEvent(PromptSuggestionClick(suggestion)) },
                     handleLink = handleLink,
+                    onCtaButtonClick = handleLink,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = messageListStyle.horizontalPadding)

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -670,20 +670,33 @@ class ConciergeChatViewModel : AndroidViewModel {
      */
     private fun replaceAssistantMessageContent(parsedMessage: ParsedConversationMessage) {
         if (parsedMessage.orderedElements.isNotEmpty()) {
-            // New ordered-elements path: text message first, then each element as its own message
-            val textContent = MessageContent.Text(parsedMessage.messageContent)
-            Log.debug(
-                ConciergeConstants.EXTENSION_NAME,
-                TAG,
-                "Replacing with final Text message (${parsedMessage.messageContent.length} chars), then appending ${parsedMessage.orderedElements.size} ordered elements."
-            )
-            updateAssistantMessageContent(
-                textContent,
-                parsedMessage.promptSuggestions,
-                parsedMessage.sources,
-                parsedMessage.interactionId,
-                sseComplete = true
-            )
+            if (parsedMessage.messageContent.isNotEmpty()) {
+                // Text + ordered elements: keep the text message, then append elements.
+                // Suppress interactionId (and thus feedback controls) when CTAs are present —
+                // service-intent responses are deterministic and don't warrant thumbs up/down.
+                val hasCtas = parsedMessage.orderedElements.any { it is ParsedMultimodalItem.Cta }
+                Log.debug(
+                    ConciergeConstants.EXTENSION_NAME,
+                    TAG,
+                    "Replacing with final Text message (${parsedMessage.messageContent.length} chars), then appending ${parsedMessage.orderedElements.size} ordered elements."
+                )
+                updateAssistantMessageContent(
+                    MessageContent.Text(parsedMessage.messageContent),
+                    parsedMessage.promptSuggestions,
+                    parsedMessage.sources,
+                    interactionId = if (hasCtas) null else parsedMessage.interactionId,
+                    sseComplete = true
+                )
+            } else {
+                // No text, ordered elements only: remove the streaming placeholder so feedback
+                // controls don't appear on an empty bubble.
+                Log.debug(
+                    ConciergeConstants.EXTENSION_NAME,
+                    TAG,
+                    "No text content, removing placeholder and appending ${parsedMessage.orderedElements.size} ordered elements."
+                )
+                removeLastAssistantPlaceholder()
+            }
             appendOrderedElementMessages(parsedMessage.orderedElements)
         } else {
             // Legacy path: text-only or mixed message
@@ -784,10 +797,21 @@ class ConciergeChatViewModel : AndroidViewModel {
                     promptSuggestions = promptSuggestions,
                     citations = sources,
                     uniqueCitations = uniqueSources,
-                    interactionId = interactionId ?: lastAssistantMessage.interactionId,
+                    interactionId = interactionId,
                     sseComplete = sseComplete ?: lastAssistantMessage.sseComplete
                 )
                 updatedMessages
+            } else {
+                existingMessages
+            }
+        }
+    }
+
+    private fun removeLastAssistantPlaceholder() {
+        _messages.update { existingMessages ->
+            val lastIndex = existingMessages.lastIndex
+            if (lastIndex >= 0 && !existingMessages[lastIndex].isFromUser) {
+                existingMessages.dropLast(1)
             } else {
                 existingMessages
             }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -612,9 +612,9 @@ class ConciergeChatViewModel : AndroidViewModel {
             }
 
             ConversationState.COMPLETED -> {
-                // For COMPLETED state, if final message is blank, keep existing content and just transition to Idle.
-                // Otherwise, replace with the final message.
-                if (parsedMessage.messageContent.isNotBlank()) {
+                // For COMPLETED state, replace content if there is text or ordered elements.
+                // If both are absent, keep existing streamed content and just transition to Idle.
+                if (parsedMessage.messageContent.isNotBlank() || parsedMessage.orderedElements.isNotEmpty()) {
                     replaceAssistantMessageContent(parsedMessage)
                 } else {
                     setLastAssistantMessageSseComplete()

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -24,6 +24,7 @@ import com.adobe.marketing.mobile.concierge.network.ConciergeConversationService
 import com.adobe.marketing.mobile.concierge.network.ConversationState
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.network.ParsedConversationMessage
+import com.adobe.marketing.mobile.concierge.network.CtaButton
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 import com.adobe.marketing.mobile.concierge.ui.config.WelcomeConfig
@@ -695,7 +696,8 @@ class ConciergeChatViewModel : AndroidViewModel {
             parsedMessage.promptSuggestions,
             parsedMessage.sources,
             parsedMessage.interactionId,
-            sseComplete = true
+            sseComplete = true,
+            ctaButton = parsedMessage.ctaButton
         )
     }
 
@@ -712,7 +714,8 @@ class ConciergeChatViewModel : AndroidViewModel {
         promptSuggestions: List<String> = emptyList(),
         sources: List<Citation> = emptyList(),
         interactionId: String? = null,
-        sseComplete: Boolean? = null
+        sseComplete: Boolean? = null,
+        ctaButton: CtaButton? = null
     ) {
         // Pre-compute unique citations once to avoid redundant processing
         val uniqueSources = if (sources.isNotEmpty()) {
@@ -732,7 +735,8 @@ class ConciergeChatViewModel : AndroidViewModel {
                     citations = sources,
                     uniqueCitations = uniqueSources,
                     interactionId = interactionId ?: lastAssistantMessage.interactionId,
-                    sseComplete = sseComplete ?: lastAssistantMessage.sseComplete
+                    sseComplete = sseComplete ?: lastAssistantMessage.sseComplete,
+                    ctaButton = ctaButton ?: lastAssistantMessage.ctaButton
                 )
                 updatedMessages
             } else {

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -24,7 +24,7 @@ import com.adobe.marketing.mobile.concierge.network.ConciergeConversationService
 import com.adobe.marketing.mobile.concierge.network.ConversationState
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.network.ParsedConversationMessage
-import com.adobe.marketing.mobile.concierge.network.CtaButton
+import com.adobe.marketing.mobile.concierge.network.ParsedMultimodalItem
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 import com.adobe.marketing.mobile.concierge.ui.config.WelcomeConfig
@@ -669,36 +669,87 @@ class ConciergeChatViewModel : AndroidViewModel {
      * @param parsedMessage The parsed message containing the final complete content
      */
     private fun replaceAssistantMessageContent(parsedMessage: ParsedConversationMessage) {
-        // Create message content - conditionally include multimodal content
-        val messageContent = if (parsedMessage.multimodalElements.isEmpty()) {
-            MessageContent.Text(parsedMessage.messageContent)
+        if (parsedMessage.orderedElements.isNotEmpty()) {
+            // New ordered-elements path: text message first, then each element as its own message
+            val textContent = MessageContent.Text(parsedMessage.messageContent)
+            Log.debug(
+                ConciergeConstants.EXTENSION_NAME,
+                TAG,
+                "Replacing with final Text message (${parsedMessage.messageContent.length} chars), then appending ${parsedMessage.orderedElements.size} ordered elements."
+            )
+            updateAssistantMessageContent(
+                textContent,
+                parsedMessage.promptSuggestions,
+                parsedMessage.sources,
+                parsedMessage.interactionId,
+                sseComplete = true
+            )
+            appendOrderedElementMessages(parsedMessage.orderedElements)
         } else {
-            MessageContent.Mixed(
-                text = parsedMessage.messageContent,
-                multimodalElements = parsedMessage.multimodalElements
+            // Legacy path: text-only or mixed message
+            val messageContent = if (parsedMessage.multimodalElements.isEmpty()) {
+                MessageContent.Text(parsedMessage.messageContent)
+            } else {
+                MessageContent.Mixed(
+                    text = parsedMessage.messageContent,
+                    multimodalElements = parsedMessage.multimodalElements
+                )
+            }
+
+            val logMessage = if (parsedMessage.multimodalElements.isEmpty()) {
+                "Replacing with final Text message with length (${parsedMessage.messageContent.length} chars)"
+            } else {
+                "Replacing with final Mixed message with text (${parsedMessage.messageContent.length} chars) and ${parsedMessage.multimodalElements.size} multimodal elements."
+            }
+
+            Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, logMessage)
+
+            updateAssistantMessageContent(
+                messageContent,
+                parsedMessage.promptSuggestions,
+                parsedMessage.sources,
+                parsedMessage.interactionId,
+                sseComplete = true
             )
         }
+    }
 
-        val logMessage = if (parsedMessage.multimodalElements.isEmpty()) {
-            "Replacing with final Text message with length (${parsedMessage.messageContent.length} chars)"
-        } else {
-            "Replacing with final Mixed message with text (${parsedMessage.messageContent.length} chars) and ${parsedMessage.multimodalElements.size} multimodal elements."
+    /**
+     * Appends standalone messages for each ordered element.
+     * All cards are batched into one Mixed message at the position of the first Card element.
+     * Each CTA becomes its own CtaButton message.
+     */
+    private fun appendOrderedElementMessages(orderedElements: List<ParsedMultimodalItem>) {
+        val cardElements = orderedElements
+            .filterIsInstance<ParsedMultimodalItem.Card>()
+            .map { it.element }
+        var cardMessageAppended = false
+
+        for (element in orderedElements) {
+            when (element) {
+                is ParsedMultimodalItem.Cta -> {
+                    val ctaMessage = ChatMessage(
+                        content = MessageContent.CtaButton(element.button),
+                        isFromUser = false,
+                        timestamp = System.currentTimeMillis(),
+                        sseComplete = true
+                    )
+                    _messages.update { it + ctaMessage }
+                }
+                is ParsedMultimodalItem.Card -> {
+                    if (!cardMessageAppended) {
+                        cardMessageAppended = true
+                        val cardMessage = ChatMessage(
+                            content = MessageContent.Mixed(text = "", multimodalElements = cardElements),
+                            isFromUser = false,
+                            timestamp = System.currentTimeMillis(),
+                            sseComplete = true
+                        )
+                        _messages.update { it + cardMessage }
+                    }
+                }
+            }
         }
-
-        Log.debug(
-            ConciergeConstants.EXTENSION_NAME,
-            TAG,
-            logMessage
-        )
-
-        updateAssistantMessageContent(
-            messageContent,
-            parsedMessage.promptSuggestions,
-            parsedMessage.sources,
-            parsedMessage.interactionId,
-            sseComplete = true,
-            ctaButton = parsedMessage.ctaButton
-        )
     }
 
     /**
@@ -714,8 +765,7 @@ class ConciergeChatViewModel : AndroidViewModel {
         promptSuggestions: List<String> = emptyList(),
         sources: List<Citation> = emptyList(),
         interactionId: String? = null,
-        sseComplete: Boolean? = null,
-        ctaButton: CtaButton? = null
+        sseComplete: Boolean? = null
     ) {
         // Pre-compute unique citations once to avoid redundant processing
         val uniqueSources = if (sources.isNotEmpty()) {
@@ -735,8 +785,7 @@ class ConciergeChatViewModel : AndroidViewModel {
                     citations = sources,
                     uniqueCitations = uniqueSources,
                     interactionId = interactionId ?: lastAssistantMessage.interactionId,
-                    sseComplete = sseComplete ?: lastAssistantMessage.sseComplete,
-                    ctaButton = ctaButton ?: lastAssistantMessage.ctaButton
+                    sseComplete = sseComplete ?: lastAssistantMessage.sseComplete
                 )
                 updatedMessages
             } else {

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -80,7 +80,11 @@ private fun RenderCtaButton(
     content: MessageContent.CtaButton,
     handleLink: (String) -> Unit
 ) {
-    CtaButton(cta = content.button, onClick = handleLink)
+    CtaButton(
+        cta = content.button,
+        onClick = handleLink,
+        applyContainerPadding = false
+    )
 }
 
 @Composable

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -68,7 +68,19 @@ internal fun ChatMessageItem(
                 onCtaButtonClick
             )
         }
+
+        is MessageContent.CtaButton -> {
+            RenderCtaButton(content = message.content, handleLink = handleLink)
+        }
     }
+}
+
+@Composable
+private fun RenderCtaButton(
+    content: MessageContent.CtaButton,
+    handleLink: (String) -> Unit
+) {
+    CtaButton(cta = content.button, onClick = handleLink)
 }
 
 @Composable
@@ -177,88 +189,85 @@ private fun RenderMixedMessage(
     onCtaButtonClick: (String) -> Unit
 ) {
     val style = ConciergeStyles.messageBubbleStyle
+    val content = message.content as MessageContent.Mixed
 
-    if (message.content is MessageContent.Mixed) {
-        Column(
-            modifier = Modifier.fillMaxWidth()
+    Column(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(style.padding),
+            colors = CardDefaults.cardColors(
+                containerColor = style.botMessageBackgroundColor
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = style.elevation),
+            shape = style.shape
         ) {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(style.padding),
-                colors = CardDefaults.cardColors(
-                    containerColor = style.botMessageBackgroundColor
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = style.elevation),
-                shape = style.shape
+            Box(
+                modifier = Modifier.padding(style.innerPadding)
             ) {
-                Box(
-                    modifier = Modifier.padding(style.innerPadding)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    ) {
-                        // Render text content if present
-                        if (message.content.text.isNotEmpty()) {
-                            ConciergeResponse(
-                                text = message.content.text,
-                                sources = message.citations ?: emptyList(),
-                                handleLink = handleLink,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
+                    // Render text content if present
+                    if (content.text.isNotEmpty()) {
+                        ConciergeResponse(
+                            text = content.text,
+                            sources = message.citations ?: emptyList(),
+                            handleLink = handleLink,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
 
-                        // Add spacing between text and recommendation cards if both are present
-                        if (message.content.text.isNotEmpty() &&
-                            !message.content.multimodalElements.isNullOrEmpty()
-                        ) {
-                            Spacer(modifier = Modifier.height(style.contentSpacing))
-                        }
+                    // Add spacing between text and recommendation cards if both are present
+                    if (content.text.isNotEmpty() && !content.multimodalElements.isNullOrEmpty()) {
+                        Spacer(modifier = Modifier.height(style.contentSpacing))
+                    }
 
-                        // Render multi-modal elements if present
-                        message.content.multimodalElements?.let { multimodalElements ->
-                            if (multimodalElements.isNotEmpty()) {
-                                RecommendationCards(
-                                    elements = multimodalElements,
-                                    onImageClick = onImageClick,
-                                    onActionClick = onActionClick
-                                )
-                            }
-                        }
-
-                        // Show footer if we have citations or have an interaction id for providing feedback
-                        if (!message.isFromUser && (message.citations != null || message.interactionId != null)) {
-                            ChatFooter(
-                                citations = message.citations,
-                                uniqueCitations = message.uniqueCitations,
-                                interactionId = message.interactionId,
-                                sseComplete = message.sseComplete,
-                                onFeedback = onFeedback,
-                                handleLink = handleLink,
-                                feedbackState = feedbackState
+                    // Render multi-modal elements if present
+                    content.multimodalElements?.let { multimodalElements ->
+                        if (multimodalElements.isNotEmpty()) {
+                            RecommendationCards(
+                                elements = multimodalElements,
+                                onImageClick = onImageClick,
+                                onActionClick = onActionClick
                             )
                         }
                     }
+
+                    // Show footer if we have citations or have an interaction id for providing feedback
+                    if (!message.isFromUser && (message.citations != null || message.interactionId != null)) {
+                        ChatFooter(
+                            citations = message.citations,
+                            uniqueCitations = message.uniqueCitations,
+                            interactionId = message.interactionId,
+                            sseComplete = message.sseComplete,
+                            onFeedback = onFeedback,
+                            handleLink = handleLink,
+                            feedbackState = feedbackState
+                        )
+                    }
                 }
             }
+        }
 
-            // Show prompt suggestions for concierge responses
-            if (!message.isFromUser && message.promptSuggestions.isNotEmpty()) {
-                PromptSuggestions(
-                    suggestions = message.promptSuggestions,
-                    onSuggestionClick = onSuggestionClick
+        // Show prompt suggestions for concierge responses
+        if (!message.isFromUser && message.promptSuggestions.isNotEmpty()) {
+            PromptSuggestions(
+                suggestions = message.promptSuggestions,
+                onSuggestionClick = onSuggestionClick
+            )
+        }
+
+        // Show service intent CTA button if present
+        message.ctaButton?.let { cta ->
+            if (!message.isFromUser) {
+                CtaButton(
+                    cta = cta,
+                    onClick = onCtaButtonClick
                 )
-            }
-
-            // Show service intent CTA button if present
-            message.ctaButton?.let { cta ->
-                if (!message.isFromUser) {
-                    CtaButton(
-                        cta = cta,
-                        onClick = onCtaButtonClick
-                    )
-                }
             }
         }
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -30,6 +30,7 @@ import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButt
 import com.adobe.marketing.mobile.concierge.ui.components.card.RecommendationCards
 import com.adobe.marketing.mobile.concierge.ui.components.footer.ChatFooter
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
+import com.adobe.marketing.mobile.concierge.ui.components.serviceintent.CtaButton
 import com.adobe.marketing.mobile.concierge.ui.components.suggestions.PromptSuggestions
 import com.adobe.marketing.mobile.concierge.ui.state.ChatMessage
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackEvent
@@ -47,11 +48,12 @@ internal fun ChatMessageItem(
     onImageClick: (MultimodalElement) -> Unit = {},
     onSuggestionClick: (String) -> Unit = {},
     handleLink: (String) -> Unit = {},
-    feedbackState: FeedbackState = FeedbackState.None
+    feedbackState: FeedbackState = FeedbackState.None,
+    onCtaButtonClick: (String) -> Unit = {}
 ) {
     when (message.content) {
         is MessageContent.Text -> {
-            RenderTextMessage(message, onFeedback, onSuggestionClick, handleLink, feedbackState)
+            RenderTextMessage(message, onFeedback, onSuggestionClick, handleLink, feedbackState, onCtaButtonClick)
         }
 
         is MessageContent.Mixed -> {
@@ -62,7 +64,8 @@ internal fun ChatMessageItem(
                 onImageClick,
                 onSuggestionClick,
                 handleLink,
-                feedbackState
+                feedbackState,
+                onCtaButtonClick
             )
         }
     }
@@ -74,7 +77,8 @@ private fun RenderTextMessage(
     onFeedback: (FeedbackEvent) -> Unit,
     onSuggestionClick: (String) -> Unit,
     handleLink: (String) -> Unit,
-    feedbackState: FeedbackState
+    feedbackState: FeedbackState,
+    onCtaButtonClick: (String) -> Unit
 ) {
     val style = ConciergeStyles.messageBubbleStyle
 
@@ -148,6 +152,16 @@ private fun RenderTextMessage(
                 onSuggestionClick = onSuggestionClick
             )
         }
+
+        // Show service intent CTA button if present
+        message.ctaButton?.let { cta ->
+            if (!message.isFromUser) {
+                CtaButton(
+                    cta = cta,
+                    onClick = onCtaButtonClick
+                )
+            }
+        }
     }
 }
 
@@ -159,7 +173,8 @@ private fun RenderMixedMessage(
     onImageClick: (MultimodalElement) -> Unit,
     onSuggestionClick: (String) -> Unit,
     handleLink: (String) -> Unit,
-    feedbackState: FeedbackState
+    feedbackState: FeedbackState,
+    onCtaButtonClick: (String) -> Unit
 ) {
     val style = ConciergeStyles.messageBubbleStyle
 
@@ -234,6 +249,16 @@ private fun RenderMixedMessage(
                     suggestions = message.promptSuggestions,
                     onSuggestionClick = onSuggestionClick
                 )
+            }
+
+            // Show service intent CTA button if present
+            message.ctaButton?.let { cta ->
+                if (!message.isFromUser) {
+                    CtaButton(
+                        cta = cta,
+                        onClick = onCtaButtonClick
+                    )
+                }
             }
         }
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/MessageList.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/MessageList.kt
@@ -44,7 +44,8 @@ internal fun MessageList(
     onActionClick: (ProductActionButton) -> Unit = {},
     onImageClick: (MultimodalElement) -> Unit = {},
     onSuggestionClick: (String) -> Unit = {},
-    handleLink: (String) -> Unit = {}
+    handleLink: (String) -> Unit = {},
+    onCtaButtonClick: (String) -> Unit = {}
 ) {
     val style = ConciergeStyles.messageListStyle
     val listState = rememberLazyListState()
@@ -97,7 +98,8 @@ internal fun MessageList(
                         onImageClick = onImageClick,
                         onSuggestionClick = onSuggestionClick,
                         handleLink = handleLink,
-                        feedbackState = message.feedbackState
+                        feedbackState = message.feedbackState,
+                        onCtaButtonClick = onCtaButtonClick
                     )
                 }
             }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/OrderedElementsPreview.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/OrderedElementsPreview.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.components.messages
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adobe.marketing.mobile.concierge.network.CtaButton as NetworkCtaButton
+import com.adobe.marketing.mobile.concierge.network.MultimodalElement
+import com.adobe.marketing.mobile.concierge.ui.state.ChatMessage
+import com.adobe.marketing.mobile.concierge.ui.state.MessageContent
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeThemeLoader
+import com.adobe.marketing.mobile.concierge.utils.image.DefaultImageProvider
+import com.adobe.marketing.mobile.concierge.utils.image.LocalImageProvider
+
+// ── Sample cards ────────────────────────────────────────────────────────────
+
+private val sampleCards = listOf(
+    MultimodalElement(
+        id = "card-1",
+        url = "https://picsum.photos/id/10/190/190",
+        content = mapOf(
+            "productName" to "Product One",
+            "productDescription" to "A short subtitle line",
+            "productPrice" to "\$49.99",
+            "productPageURL" to "https://example.com/1"
+        )
+    ),
+    MultimodalElement(
+        id = "card-2",
+        url = "https://picsum.photos/id/20/190/190",
+        content = mapOf(
+            "productName" to "Product Two",
+            "productDescription" to "Another subtitle",
+            "productPrice" to "\$89.99",
+            "productWasPrice" to "\$119.99",
+            "productBadge" to "Sale",
+            "productPageURL" to "https://example.com/2"
+        )
+    ),
+    MultimodalElement(
+        id = "card-3",
+        url = "https://picsum.photos/id/30/190/190",
+        content = mapOf(
+            "productName" to "Product Three Long Title That May Wrap",
+            "productDescription" to "Subtitle goes here for context",
+            "productPrice" to "\$24.95",
+            "productPageURL" to "https://example.com/3"
+        )
+    )
+)
+
+// ── Sample CTAs ──────────────────────────────────────────────────────────────
+
+private val ctaShop = NetworkCtaButton(label = "Shop All", url = "https://example.com/shop")
+private val ctaLearn = NetworkCtaButton(label = "Learn More", url = "https://example.com/learn")
+private val ctaGetStarted = NetworkCtaButton(label = "Get Started", url = "https://example.com/start")
+private val ctaCompare = NetworkCtaButton(label = "Compare Options", url = "https://example.com/compare")
+private val ctaContact = NetworkCtaButton(label = "Contact Support", url = "https://example.com/contact")
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Builds the sequence of [ChatMessage]s for one conversation turn.
+ * [userText] is the user query; [botText] is the assistant reply; [elements] are
+ * the ordered element messages exactly as [ConciergeChatViewModel.appendOrderedElementMessages]
+ * would append them (each CTA becomes a standalone message, all cards are one batched Mixed).
+ */
+private fun turn(
+    userText: String,
+    botText: String,
+    elements: List<MessageContent>,
+    baseTimestamp: Long,
+    interactionId: String
+): List<ChatMessage> = buildList {
+    add(ChatMessage(content = MessageContent.Text(userText), isFromUser = true, timestamp = baseTimestamp))
+    add(ChatMessage(content = MessageContent.Text(botText), isFromUser = false, timestamp = baseTimestamp + 1, sseComplete = true, interactionId = interactionId))
+    elements.forEachIndexed { i, content ->
+        add(ChatMessage(content = content, isFromUser = false, timestamp = baseTimestamp + 2 + i, sseComplete = true))
+    }
+}
+
+private fun ctaContent(button: NetworkCtaButton) = MessageContent.CtaButton(button)
+private fun cardsContent(cards: List<MultimodalElement>) = MessageContent.Mixed(text = "", multimodalElements = cards)
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+// Each scenario reflects the exact message list the ViewModel produces.
+// Cards are always batched into one Mixed message at the first card's array position.
+
+private val allMessages: List<ChatMessage> = buildList {
+    // 1. Text-only response (no ordered elements)
+    addAll(turn(
+        userText = "What can you help me with?",
+        botText = "I can assist with product recommendations, pricing, and support questions.",
+        elements = emptyList(),
+        baseTimestamp = 100L,
+        interactionId = "turn-1"
+    ))
+
+    // 2. Single CTA
+    addAll(turn(
+        userText = "How do I get started?",
+        botText = "It's easy! Tap the button below to begin.",
+        elements = listOf(ctaContent(ctaGetStarted)),
+        baseTimestamp = 200L,
+        interactionId = "turn-2"
+    ))
+
+    // 3. Three CTAs (no cards) — each in its own message
+    addAll(turn(
+        userText = "What are my options?",
+        botText = "Here are a few ways I can help:",
+        elements = listOf(ctaContent(ctaShop), ctaContent(ctaLearn), ctaContent(ctaContact)),
+        baseTimestamp = 300L,
+        interactionId = "turn-3"
+    ))
+
+    // 4. Two product cards only — batched as one carousel message
+    addAll(turn(
+        userText = "Show me some products",
+        botText = "Here are a couple of options that match your search:",
+        elements = listOf(cardsContent(sampleCards.take(2))),
+        baseTimestamp = 400L,
+        interactionId = "turn-4"
+    ))
+
+    // 5. Three product cards — batched into a single carousel
+    addAll(turn(
+        userText = "Show me more products",
+        botText = "I found a few more items you might like:",
+        elements = listOf(cardsContent(sampleCards)),
+        baseTimestamp = 500L,
+        interactionId = "turn-5"
+    ))
+
+    // 6. CTA before cards [CTA, Card, Card]
+    // → text | CTA | cards carousel
+    addAll(turn(
+        userText = "Can you recommend something?",
+        botText = "Sure! You can also browse everything, or check out these specific picks:",
+        elements = listOf(ctaContent(ctaShop), cardsContent(sampleCards.take(2))),
+        baseTimestamp = 600L,
+        interactionId = "turn-6"
+    ))
+
+    // 7. Cards before CTA [Card, Card, CTA]
+    // → text | cards carousel | CTA
+    addAll(turn(
+        userText = "I'm looking for deals",
+        botText = "These are currently on sale. Want to see the full catalog?",
+        elements = listOf(cardsContent(sampleCards.take(2)), ctaContent(ctaShop)),
+        baseTimestamp = 700L,
+        interactionId = "turn-7"
+    ))
+
+    // 8. CTA, one card, CTA [CTA, Card, CTA]
+    // Cards batch at first card position (after first CTA).
+    // → text | CTA | cards carousel | CTA
+    addAll(turn(
+        userText = "Give me a mixed layout",
+        botText = "Here's a mix of actions and products:",
+        elements = listOf(ctaContent(ctaLearn), cardsContent(sampleCards.take(1)), ctaContent(ctaCompare)),
+        baseTimestamp = 800L,
+        interactionId = "turn-8"
+    ))
+
+    // 9. Complex: two CTAs + three cards interleaved [CTA, Card, CTA, Card, Card]
+    // Cards batch at first card position (after first CTA).
+    // → text | CTA | cards carousel (all 3) | CTA
+    addAll(turn(
+        userText = "Show me everything",
+        botText = "Here's a comprehensive response with both actions and product recommendations:",
+        elements = listOf(
+            ctaContent(ctaGetStarted),
+            cardsContent(sampleCards),          // all 3 cards batched here
+            ctaContent(ctaContact)
+        ),
+        baseTimestamp = 900L,
+        interactionId = "turn-9"
+    ))
+}
+
+// ── Demo composable ──────────────────────────────────────────────────────────
+
+/**
+ * Demo screen rendering a series of conversation turns that cover every combination
+ * of CTA buttons and product cards in the ordered-elements architecture.
+ *
+ * Scenarios (in order):
+ * 1. Text only
+ * 2. Text + 1 CTA
+ * 3. Text + 3 CTAs
+ * 4. Text + 2 cards
+ * 5. Text + 3 cards
+ * 6. Text + CTA → cards (CTA first)
+ * 7. Text + cards → CTA (cards first)
+ * 8. Text + CTA → card → CTA
+ * 9. Text + CTA → cards (×3) → CTA (complex mixed)
+ */
+@Composable
+internal fun OrderedElementsDemoScreen() {
+    CompositionLocalProvider(LocalImageProvider provides DefaultImageProvider()) {
+        ConciergeTheme(theme = ConciergeThemeLoader.default()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xFFF5F5F5))
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = "Ordered Elements — All Scenarios",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF333333),
+                    modifier = Modifier.padding(start = 16.dp, top = 20.dp, bottom = 4.dp)
+                )
+                Text(
+                    text = "Text only • 1 CTA • 3 CTAs • 2 cards • 3 cards • CTA+cards • cards+CTA • CTA+card+CTA • complex",
+                    fontSize = 11.sp,
+                    color = Color(0xFF888888),
+                    modifier = Modifier.padding(start = 16.dp, bottom = 12.dp)
+                )
+
+                HorizontalDivider(color = Color(0xFFDDDDDD))
+
+                MessageList(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(4200.dp), // fixed height large enough for all scenarios
+                    messages = allMessages
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF5F5F5, widthDp = 400, heightDp = 4400)
+@Composable
+internal fun OrderedElementsPreview() {
+    OrderedElementsDemoScreen()
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/OrderedElementsPreview.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/OrderedElementsPreview.kt
@@ -92,6 +92,7 @@ private val ctaContact = NetworkCtaButton(label = "Contact Support", url = "http
  * the ordered element messages exactly as [ConciergeChatViewModel.appendOrderedElementMessages]
  * would append them (each CTA becomes a standalone message, all cards are one batched Mixed).
  */
+@OptIn(ExperimentalStdlibApi::class)
 private fun turn(
     userText: String,
     botText: String,
@@ -113,6 +114,7 @@ private fun cardsContent(cards: List<MultimodalElement>) = MessageContent.Mixed(
 // Each scenario reflects the exact message list the ViewModel produces.
 // Cards are always batched into one Mixed message at the first card's array position.
 
+@OptIn(ExperimentalStdlibApi::class)
 private val allMessages: List<ChatMessage> = buildList {
     // 1. Text-only response (no ordered elements)
     addAll(turn(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/serviceintent/ServiceIntentButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/serviceintent/ServiceIntentButton.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.components.serviceintent
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.adobe.marketing.mobile.concierge.R
+import com.adobe.marketing.mobile.concierge.network.CtaButton
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
+
+/**
+ * Displays a CTA pill button (e.g., "Chat with a teammate ↗")
+ * below a bot message.
+ *
+ * @param cta The CTA button data containing the label and URL
+ * @param onClick Callback invoked with the CTA URL when the button is clicked
+ * @param modifier Optional modifier for the container
+ */
+@Composable
+internal fun CtaButton(
+    cta: CtaButton,
+    onClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val style = ConciergeStyles.ctaButtonStyle
+
+    Card(
+        modifier = modifier
+            .padding(
+                top = style.containerTopPadding,
+                start = style.containerStartPadding
+            )
+            .clickable { onClick(cta.url) },
+        colors = CardDefaults.cardColors(
+            containerColor = style.backgroundColor
+        ),
+        shape = style.shape,
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = style.horizontalPadding,
+                vertical = style.verticalPadding
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(style.iconSpacing)
+        ) {
+            Text(
+                text = cta.label,
+                style = style.textStyle,
+                color = style.textColor
+            )
+            Icon(
+                painter = painterResource(id = R.drawable.open_in_new),
+                contentDescription = null,
+                modifier = Modifier.size(style.iconSize),
+                tint = style.iconColor
+            )
+        }
+    }
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/serviceintent/ServiceIntentButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/serviceintent/ServiceIntentButton.kt
@@ -31,7 +31,7 @@ import com.adobe.marketing.mobile.concierge.network.CtaButton
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 
 /**
- * Displays a CTA pill button (e.g., "Chat with a teammate ↗")
+ * Displays a CTA pill button (e.g., "Chat now ↗")
  * below a bot message.
  *
  * @param cta The CTA button data containing the label and URL
@@ -42,15 +42,18 @@ import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 internal fun CtaButton(
     cta: CtaButton,
     onClick: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    applyContainerPadding: Boolean = true
 ) {
     val style = ConciergeStyles.ctaButtonStyle
 
     Card(
         modifier = modifier
-            .padding(
-                top = style.containerTopPadding,
-                start = style.containerStartPadding
+            .then(
+                if (applyContainerPadding) Modifier.padding(
+                    top = style.containerTopPadding,
+                    start = style.containerStartPadding
+                ) else Modifier
             )
             .clickable { onClick(cta.url) },
         colors = CardDefaults.cardColors(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenState.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenState.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.concierge.ui.state
 
 import com.adobe.marketing.mobile.concierge.network.Citation
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
+import com.adobe.marketing.mobile.concierge.network.CtaButton
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 
@@ -161,7 +162,8 @@ internal data class ChatMessage(
     val interactionId: String? = null,
     val sseComplete: Boolean = false,
     val promptSuggestions: List<String> = emptyList(),
-    val feedbackState: FeedbackState = FeedbackState.None
+    val feedbackState: FeedbackState = FeedbackState.None,
+    val ctaButton: CtaButton? = null
 ) {
     val text: String
         get() = when (content) {

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenState.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenState.kt
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.concierge.ui.state
 
 import com.adobe.marketing.mobile.concierge.network.Citation
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
-import com.adobe.marketing.mobile.concierge.network.CtaButton
+import com.adobe.marketing.mobile.concierge.network.CtaButton as NetworkCtaButton
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 
@@ -148,6 +148,7 @@ internal sealed class MessageContent {
         val text: String,
         val multimodalElements: List<MultimodalElement>? = null
     ) : MessageContent()
+    data class CtaButton(val button: NetworkCtaButton) : MessageContent()
 }
 
 /**
@@ -163,11 +164,12 @@ internal data class ChatMessage(
     val sseComplete: Boolean = false,
     val promptSuggestions: List<String> = emptyList(),
     val feedbackState: FeedbackState = FeedbackState.None,
-    val ctaButton: CtaButton? = null
+    val ctaButton: NetworkCtaButton? = null
 ) {
     val text: String
         get() = when (content) {
             is MessageContent.Text -> content.text
             is MessageContent.Mixed -> content.text
+            is MessageContent.CtaButton -> content.button.label
         }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -136,6 +136,22 @@ internal object CSSKeyMapper {
     }
     
     /**
+     * Helper to update CTA button colors
+     */
+    private fun updateCtaButtonColors(
+        cssValue: String,
+        theme: ConciergeThemeTokens,
+        updater: (ConciergeCtaButtonColors?, String) -> ConciergeCtaButtonColors
+    ): ConciergeThemeTokens {
+        val color = CSSValueConverter.parseColor(cssValue)
+        return updateColors(theme) { colors ->
+            val ctaButtonColors = updater(colors?.ctaButton, color.toHexString())
+            colors?.copy(ctaButton = ctaButtonColors)
+                ?: ConciergeThemeColors(ctaButton = ctaButtonColors)
+        }
+    }
+
+    /**
      * Helper to update citation colors
      */
     private fun updateCitationColors(
@@ -708,6 +724,61 @@ internal object CSSKeyMapper {
             updateLayout(theme) { layout ->
                 val spacing = CSSValueConverter.parsePxValue(cssValue) ?: 12.0
                 layout?.copy(productCardCarouselSpacing = spacing) ?: ConciergeLayout(productCardCarouselSpacing = spacing)
+            }
+        },
+
+        // Layout - CTA button
+        "cta-button-border-radius" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val radius = CSSValueConverter.parsePxValue(cssValue) ?: 99.0
+                layout?.copy(ctaButtonBorderRadius = radius) ?: ConciergeLayout(ctaButtonBorderRadius = radius)
+            }
+        },
+        "cta-button-horizontal-padding" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val padding = CSSValueConverter.parsePxValue(cssValue) ?: 16.0
+                layout?.copy(ctaButtonHorizontalPadding = padding) ?: ConciergeLayout(ctaButtonHorizontalPadding = padding)
+            }
+        },
+        "cta-button-vertical-padding" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val padding = CSSValueConverter.parsePxValue(cssValue) ?: 12.0
+                layout?.copy(ctaButtonVerticalPadding = padding) ?: ConciergeLayout(ctaButtonVerticalPadding = padding)
+            }
+        },
+        "cta-button-font-size" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val size = CSSValueConverter.parsePxValue(cssValue) ?: 14.0
+                layout?.copy(ctaButtonFontSize = size) ?: ConciergeLayout(ctaButtonFontSize = size)
+            }
+        },
+        "cta-button-font-weight" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val weight = CSSValueConverter.parseFontWeight(cssValue)
+                layout?.copy(ctaButtonFontWeight = weight) ?: ConciergeLayout(ctaButtonFontWeight = weight)
+            }
+        },
+        "cta-button-icon-size" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val size = CSSValueConverter.parsePxValue(cssValue) ?: 16.0
+                layout?.copy(ctaButtonIconSize = size) ?: ConciergeLayout(ctaButtonIconSize = size)
+            }
+        },
+
+        // Colors - CTA Button (using helper)
+        "cta-button-background-color" to { cssValue, theme ->
+            updateCtaButtonColors(cssValue, theme) { existing, color ->
+                existing?.copy(backgroundColor = color) ?: ConciergeCtaButtonColors(backgroundColor = color)
+            }
+        },
+        "cta-button-text-color" to { cssValue, theme ->
+            updateCtaButtonColors(cssValue, theme) { existing, color ->
+                existing?.copy(textColor = color) ?: ConciergeCtaButtonColors(textColor = color)
+            }
+        },
+        "cta-button-icon-color" to { cssValue, theme ->
+            updateCtaButtonColors(cssValue, theme) { existing, color ->
+                existing?.copy(iconColor = color) ?: ConciergeCtaButtonColors(iconColor = color)
             }
         },
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -78,7 +78,12 @@ data class ConciergeColors(
     // Citation/Disclaimer colors (from CSS themes)
     val citationBackground: Color? = null,
     val citationText: Color? = null,
-    val disclaimerColor: Color? = null
+    val disclaimerColor: Color? = null,
+
+    // CTA button colors (from CSS themes)
+    val ctaButtonBackground: Color? = null,
+    val ctaButtonText: Color? = null,
+    val ctaButtonIcon: Color? = null
 )
 
 /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -613,6 +613,44 @@ internal object ConciergeStyles {
         }
 
     /**
+     * Styling for CTA button
+     */
+    @Immutable
+    data class CtaButtonStyle(
+        val containerTopPadding: Dp,
+        val containerStartPadding: Dp,
+        val shape: Shape,
+        val backgroundColor: Color,
+        val horizontalPadding: Dp,
+        val verticalPadding: Dp,
+        val iconSize: Dp,
+        val iconColor: Color,
+        val iconSpacing: Dp,
+        val textStyle: TextStyle,
+        val textColor: Color
+    )
+
+    val ctaButtonStyle: CtaButtonStyle
+        @Composable get() {
+            return CtaButtonStyle(
+                containerTopPadding = 6.dp,
+                containerStartPadding = 12.dp,
+                shape = RoundedCornerShape(99.dp),
+                backgroundColor = Color(0xFFEDEDED),
+                horizontalPadding = 16.dp,
+                verticalPadding = 12.dp,
+                iconSize = 16.dp,
+                iconColor = Color(0xFF161313),
+                iconSpacing = 4.dp,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Normal
+                ),
+                textColor = Color(0xFF191F1C)
+            )
+        }
+
+    /**
      * Styling for citation items
      */
     @Immutable

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -632,21 +632,26 @@ internal object ConciergeStyles {
 
     val ctaButtonStyle: CtaButtonStyle
         @Composable get() {
+            val themeColors = ConciergeTheme.colors
+            val ctaLayout = ConciergeTheme.tokens?.cssLayout
+            val borderRadius = ctaLayout?.ctaButtonBorderRadius?.dp ?: 99.dp
+            val fontWeight = ctaLayout?.ctaButtonFontWeight?.let { FontWeight(it) } ?: FontWeight.Normal
+            val fontSize = ctaLayout?.ctaButtonFontSize?.sp ?: 14.sp
             return CtaButtonStyle(
                 containerTopPadding = 6.dp,
                 containerStartPadding = 12.dp,
-                shape = RoundedCornerShape(99.dp),
-                backgroundColor = Color(0xFFEDEDED),
-                horizontalPadding = 16.dp,
-                verticalPadding = 12.dp,
-                iconSize = 16.dp,
-                iconColor = Color(0xFF161313),
+                shape = RoundedCornerShape(borderRadius),
+                backgroundColor = themeColors.ctaButtonBackground ?: Color(0xFFEDEDED),
+                horizontalPadding = ctaLayout?.ctaButtonHorizontalPadding?.dp ?: 16.dp,
+                verticalPadding = ctaLayout?.ctaButtonVerticalPadding?.dp ?: 12.dp,
+                iconSize = ctaLayout?.ctaButtonIconSize?.dp ?: 16.dp,
+                iconColor = themeColors.ctaButtonIcon ?: Color(0xFF161313),
                 iconSpacing = 4.dp,
                 textStyle = MaterialTheme.typography.bodyMedium.copy(
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Normal
+                    fontSize = fontSize,
+                    fontWeight = fontWeight
                 ),
-                textColor = Color(0xFF191F1C)
+                textColor = themeColors.ctaButtonText ?: Color(0xFF191F1C)
             )
         }
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -142,7 +142,8 @@ data class ConciergeThemeColors(
     val button: ConciergeButtonColors? = null,
     val input: ConciergeInputColors? = null,
     val feedback: ConciergeFeedbackColors? = null,
-    val citation: ConciergeCitationColors? = null
+    val citation: ConciergeCitationColors? = null,
+    val ctaButton: ConciergeCtaButtonColors? = null
 )
 
 /**
@@ -197,6 +198,12 @@ data class ConciergeFeedbackColors(
 data class ConciergeCitationColors(
     val backgroundColor: String? = null,
     val textColor: String? = null
+)
+
+data class ConciergeCtaButtonColors(
+    val backgroundColor: String? = null,
+    val textColor: String? = null,
+    val iconColor: String? = null
 )
 
 /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -116,6 +116,14 @@ data class ConciergeLayout(
     val productCardCarouselHorizontalPadding: Double? = null,
     val productCardCarouselSpacing: Double? = null,
 
+    // CTA button layout
+    val ctaButtonBorderRadius: Double? = null,
+    val ctaButtonHorizontalPadding: Double? = null,
+    val ctaButtonVerticalPadding: Double? = null,
+    val ctaButtonFontSize: Double? = null,
+    val ctaButtonFontWeight: Int? = null,
+    val ctaButtonIconSize: Double? = null,
+
     // Nested layout for hierarchical themes
     val spacing: ConciergeSpacingLayout? = null,
     val sizing: ConciergeSizingLayout? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -324,7 +324,11 @@ internal object ThemeParser {
             // Citation/Disclaimer colors from CSS themes
             citationBackground = themeColors.citation?.backgroundColor?.toComposeColor(),
             citationText = themeColors.citation?.textColor?.toComposeColor(),
-            disclaimerColor = themeColors.disclaimer?.toComposeColor()
+            disclaimerColor = themeColors.disclaimer?.toComposeColor(),
+            // CTA button colors from CSS themes
+            ctaButtonBackground = themeColors.ctaButton?.backgroundColor?.toComposeColor(),
+            ctaButtonText = themeColors.ctaButton?.textColor?.toComposeColor(),
+            ctaButtonIcon = themeColors.ctaButton?.iconColor?.toComposeColor()
         )
         
         return result

--- a/code/concierge/src/main/res/drawable/open_in_new.xml
+++ b/code/concierge/src/main/res/drawable/open_in_new.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright 2025 Adobe. All rights reserved.
+  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under
+  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  ~ OF ANY KIND, either express or implied. See the License for the specific language
+  ~ governing permissions and limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <!--
+        Arrow-Open-In-New icon: external link indicator.
+        Vector positioned at left: 2px, top: 2px, 12x12 within a 16x16 frame.
+    -->
+    <path
+        android:fillColor="#161313"
+        android:pathData="M14,14H2V2h6V0H2C0.9,0 0,0.9 0,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8h-2V14zM8,0v2h3.59L4.76,8.83l1.41,1.41L13,3.41V7h2V0H8z"/>
+</vector>

--- a/code/concierge/src/main/res/drawable/open_in_new.xml
+++ b/code/concierge/src/main/res/drawable/open_in_new.xml
@@ -1,24 +1,27 @@
 <!--
-  ~ Copyright 2025 Adobe. All rights reserved.
-  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License. You may obtain a copy
-  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software distributed under
-  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-  ~ OF ANY KIND, either express or implied. See the License for the specific language
-  ~ governing permissions and limitations under the License.
-  -->
+
+    Copyright 2026 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
     android:height="16dp"
-    android:viewportWidth="16"
-    android:viewportHeight="16">
-    <!--
-        Arrow-Open-In-New icon: external link indicator.
-        Vector positioned at left: 2px, top: 2px, 12x12 within a 16x16 frame.
-    -->
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
-        android:fillColor="#161313"
-        android:pathData="M14,14H2V2h6V0H2C0.9,0 0,0.9 0,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8h-2V14zM8,0v2h3.59L4.76,8.83l1.41,1.41L13,3.41V7h2V0H8z"/>
+        android:pathData="M14,3L14,5L17.59,5L7.76,14.83L9.17,16.24L19,6.41L19,10L21,10L21,3L14,3Z"
+        android:strokeWidth="0"
+        android:fillColor="#222"/>
+    <path
+        android:pathData="M19,19L5,19L5,5L12,5L12,3L5,3C3.89,3 3,3.9 3,5L3,19C3,20.1 3.89,21 5,21L19,21C20.1,21 21,20.1 21,19L21,12L19,12L19,19Z"
+        android:strokeWidth="0"
+        android:fillColor="#222"/>
 </vector>

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
@@ -2051,10 +2051,10 @@ class ConversationResponseParserTest {
         assertNull(source.endIndex)
     }
 
-    // ========== CTA Button Tests ==========
+    // ========== Ordered Elements / CTA Button Tests ==========
 
     @Test
-    fun `parseConversationData parses ctaButton from elements array`() {
+    fun `parseConversationData parses CTA into orderedElements`() {
         val json = """
             {
               "handle": [
@@ -2067,13 +2067,11 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
                               "entity_info": {
-                                "primary": {
-                                  "text": "Chat now",
-                                  "url": "https://www.example.com/live-chat"
-                                }
+                                "label": "Chat now",
+                                "url": "https://www.example.com/live-chat"
                               }
                             }
                           ]
@@ -2089,13 +2087,14 @@ class ConversationResponseParserTest {
 
         val result = ConversationResponseParser.parseConversationData(json)
         assertEquals(1, result.size)
-        assertNotNull(result[0].ctaButton)
-        assertEquals("Chat now", result[0].ctaButton!!.label)
-        assertEquals("https://www.example.com/live-chat", result[0].ctaButton!!.url)
+        assertEquals(1, result[0].orderedElements.size)
+        val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
+        assertEquals("Chat now", cta.button.label)
+        assertEquals("https://www.example.com/live-chat", cta.button.url)
     }
 
     @Test
-    fun `parseConversationData ctaButton element is excluded from multimodalElements`() {
+    fun `parseConversationData CTA is excluded from multimodalElements`() {
         val json = """
             {
               "handle": [
@@ -2115,13 +2114,11 @@ class ConversationResponseParserTest {
                               }
                             },
                             {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
                               "entity_info": {
-                                "primary": {
-                                  "text": "Chat now",
-                                  "url": "https://example.com/chat"
-                                }
+                                "label": "Chat now",
+                                "url": "https://example.com/chat"
                               }
                             }
                           ]
@@ -2137,16 +2134,15 @@ class ConversationResponseParserTest {
 
         val result = ConversationResponseParser.parseConversationData(json)
         assertEquals(1, result.size)
-        // Product card should be in multimodalElements
         assertEquals(1, result[0].multimodalElements.size)
         assertEquals("product-1", result[0].multimodalElements[0].id)
-        // CTA button should be parsed separately
-        assertNotNull(result[0].ctaButton)
-        assertEquals("Chat now", result[0].ctaButton!!.label)
+        assertEquals(2, result[0].orderedElements.size)
+        assertTrue(result[0].orderedElements[0] is ParsedMultimodalItem.Card)
+        assertTrue(result[0].orderedElements[1] is ParsedMultimodalItem.Cta)
     }
 
     @Test
-    fun `parseConversationData ctaButton is null when no ctaButton element present`() {
+    fun `parseConversationData orderedElements empty when no multimodalElements`() {
         val json = """
             {
               "handle": [
@@ -2167,11 +2163,11 @@ class ConversationResponseParserTest {
 
         val result = ConversationResponseParser.parseConversationData(json)
         assertEquals(1, result.size)
-        assertNull(result[0].ctaButton)
+        assertTrue(result[0].orderedElements.isEmpty())
     }
 
     @Test
-    fun `parseConversationData ctaButton is null when multimodalElements is array format`() {
+    fun `parseConversationData orderedElements empty when multimodalElements is array format`() {
         val json = """
             {
               "handle": [
@@ -2193,45 +2189,11 @@ class ConversationResponseParserTest {
 
         val result = ConversationResponseParser.parseConversationData(json)
         assertEquals(1, result.size)
-        assertNull(result[0].ctaButton)
+        assertTrue(result[0].orderedElements.isEmpty())
     }
 
     @Test
-    fun `parseConversationData ctaButton is null when entity_info primary is missing`() {
-        val json = """
-            {
-              "handle": [
-                {
-                  "type": "brand-concierge:conversation",
-                  "payload": [
-                    {
-                      "response": {
-                        "message": "Incomplete CTA",
-                        "multimodalElements": {
-                          "elements": [
-                            {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
-                              "entity_info": {}
-                            }
-                          ]
-                        }
-                      },
-                      "state": "completed"
-                    }
-                  ]
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val result = ConversationResponseParser.parseConversationData(json)
-        assertEquals(1, result.size)
-        assertNull(result[0].ctaButton)
-    }
-
-    @Test
-    fun `parseConversationData ctaButton is null when primary text is empty`() {
+    fun `parseConversationData ignores CTA element with missing label`() {
         val json = """
             {
               "handle": [
@@ -2244,139 +2206,9 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
-                              "entity_info": {
-                                "primary": {
-                                  "text": "",
-                                  "url": "https://example.com/chat"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "state": "completed"
-                    }
-                  ]
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val result = ConversationResponseParser.parseConversationData(json)
-        assertEquals(1, result.size)
-        assertNull(result[0].ctaButton)
-    }
-
-    @Test
-    fun `parseConversationData ctaButton is null when primary url is empty`() {
-        val json = """
-            {
-              "handle": [
-                {
-                  "type": "brand-concierge:conversation",
-                  "payload": [
-                    {
-                      "response": {
-                        "message": "CTA missing url",
-                        "multimodalElements": {
-                          "elements": [
-                            {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
-                              "entity_info": {
-                                "primary": {
-                                  "text": "Chat now",
-                                  "url": ""
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "state": "completed"
-                    }
-                  ]
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val result = ConversationResponseParser.parseConversationData(json)
-        assertEquals(1, result.size)
-        assertNull(result[0].ctaButton)
-    }
-
-    @Test
-    fun `parseConversationData ctaButton uses first ctaButton element when multiple present`() {
-        val json = """
-            {
-              "handle": [
-                {
-                  "type": "brand-concierge:conversation",
-                  "payload": [
-                    {
-                      "response": {
-                        "message": "Multiple CTAs",
-                        "multimodalElements": {
-                          "elements": [
-                            {
-                              "type": "ctaButton",
+                              "elementType": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "primary": {
-                                  "text": "First CTA",
-                                  "url": "https://example.com/first"
-                                }
-                              }
-                            },
-                            {
-                              "type": "ctaButton",
-                              "id": "cta-2",
-                              "entity_info": {
-                                "primary": {
-                                  "text": "Second CTA",
-                                  "url": "https://example.com/second"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "state": "completed"
-                    }
-                  ]
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val result = ConversationResponseParser.parseConversationData(json)
-        assertEquals(1, result.size)
-        assertNotNull(result[0].ctaButton)
-        assertEquals("First CTA", result[0].ctaButton!!.label)
-        assertEquals("https://example.com/first", result[0].ctaButton!!.url)
-    }
-
-    @Test
-    fun `parseConversationData ctaButton falls back to root element when entity_info absent`() {
-        val json = """
-            {
-              "handle": [
-                {
-                  "type": "brand-concierge:conversation",
-                  "payload": [
-                    {
-                      "response": {
-                        "message": "CTA without entity_info",
-                        "multimodalElements": {
-                          "elements": [
-                            {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
-                              "primary": {
-                                "text": "Chat now",
                                 "url": "https://example.com/chat"
                               }
                             }
@@ -2393,13 +2225,217 @@ class ConversationResponseParserTest {
 
         val result = ConversationResponseParser.parseConversationData(json)
         assertEquals(1, result.size)
-        assertNotNull(result[0].ctaButton)
-        assertEquals("Chat now", result[0].ctaButton!!.label)
-        assertEquals("https://example.com/chat", result[0].ctaButton!!.url)
+        assertTrue(result[0].orderedElements.isEmpty())
     }
 
     @Test
-    fun `parseConversationData parses ctaButton alongside product cards and sources`() {
+    fun `parseConversationData ignores CTA element with missing url`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "CTA missing url",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
+                              "entity_info": {
+                                "label": "Chat now"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertTrue(result[0].orderedElements.isEmpty())
+    }
+
+    @Test
+    fun `parseConversationData preserves interleaved order of CTAs and cards`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Interleaved",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
+                              "entity_info": { "label": "Shop All", "url": "https://example.com/shop" }
+                            },
+                            {
+                              "id": "card-1",
+                              "entity_info": { "productName": "Product A" }
+                            },
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-2",
+                              "entity_info": { "label": "Learn More", "url": "https://example.com/learn" }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val elements = result[0].orderedElements
+        assertEquals(3, elements.size)
+        assertTrue(elements[0] is ParsedMultimodalItem.Cta)
+        assertEquals("Shop All", (elements[0] as ParsedMultimodalItem.Cta).button.label)
+        assertTrue(elements[1] is ParsedMultimodalItem.Card)
+        assertTrue(elements[2] is ParsedMultimodalItem.Cta)
+        assertEquals("Learn More", (elements[2] as ParsedMultimodalItem.Cta).button.label)
+    }
+
+    @Test
+    fun `parseConversationData parses multiple CTAs as separate Cta items`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Multiple CTAs",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
+                              "entity_info": { "label": "First", "url": "https://example.com/first" }
+                            },
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-2",
+                              "entity_info": { "label": "Second", "url": "https://example.com/second" }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val elements = result[0].orderedElements
+        assertEquals(2, elements.size)
+        assertEquals("First", (elements[0] as ParsedMultimodalItem.Cta).button.label)
+        assertEquals("Second", (elements[1] as ParsedMultimodalItem.Cta).button.label)
+    }
+
+    @Test
+    fun `parseConversationData CTA uses text field as label fallback`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "CTA text fallback",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
+                              "entity_info": {
+                                "text": "Click Me",
+                                "url": "https://example.com"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
+        assertEquals("Click Me", cta.button.label)
+    }
+
+    @Test
+    fun `parseConversationData cards-only produces Card items in orderedElements`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Cards only",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "id": "card-1",
+                              "entity_info": { "productName": "Product A" }
+                            },
+                            {
+                              "id": "card-2",
+                              "entity_info": { "productName": "Product B" }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val elements = result[0].orderedElements
+        assertEquals(2, elements.size)
+        assertTrue(elements[0] is ParsedMultimodalItem.Card)
+        assertTrue(elements[1] is ParsedMultimodalItem.Card)
+        assertEquals(2, result[0].multimodalElements.size)
+    }
+
+    @Test
+    fun `parseConversationData parses CTAs alongside product cards and sources`() {
         val json = """
             {
               "handle": [
@@ -2422,13 +2458,11 @@ class ConversationResponseParserTest {
                               }
                             },
                             {
-                              "type": "ctaButton",
-                              "id": "service-intent-live-chat",
+                              "elementType": "ctaButton",
+                              "id": "cta-1",
                               "entity_info": {
-                                "primary": {
-                                  "text": "Chat with us",
-                                  "url": "https://example.com/chat"
-                                }
+                                "label": "Chat with us",
+                                "url": "https://example.com/chat"
                               }
                             }
                           ]
@@ -2457,9 +2491,11 @@ class ConversationResponseParserTest {
         assertEquals("Great Product", message.multimodalElements[0].title)
         assertEquals(1, message.sources.size)
         assertEquals(1, message.promptSuggestions.size)
-        assertNotNull(message.ctaButton)
-        assertEquals("Chat with us", message.ctaButton!!.label)
-        assertEquals("https://example.com/chat", message.ctaButton!!.url)
+        assertEquals(2, message.orderedElements.size)
+        assertTrue(message.orderedElements[0] is ParsedMultimodalItem.Card)
+        val cta = message.orderedElements[1] as ParsedMultimodalItem.Cta
+        assertEquals("Chat with us", cta.button.label)
+        assertEquals("https://example.com/chat", cta.button.url)
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
@@ -17,7 +17,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class TempConversationResponseParserTest {
+class ConversationResponseParserTest {
 
     @Test
     fun `parseConversationData returns empty list for blank input`() {
@@ -2049,6 +2049,417 @@ class TempConversationResponseParserTest {
         assertEquals(1, source.citationNumber)
         assertNull(source.startIndex)
         assertNull(source.endIndex)
+    }
+
+    // ========== CTA Button Tests ==========
+
+    @Test
+    fun `parseConversationData parses ctaButton from elements array`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Need help?",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://www.example.com/live-chat"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNotNull(result[0].ctaButton)
+        assertEquals("Chat now", result[0].ctaButton!!.label)
+        assertEquals("https://www.example.com/live-chat", result[0].ctaButton!!.url)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton element is excluded from multimodalElements`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Here is a product and a CTA",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "id": "product-1",
+                              "entity_info": {
+                                "productName": "My Product",
+                                "productImageURL": "https://example.com/img.jpg"
+                              }
+                            },
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://example.com/chat"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        // Product card should be in multimodalElements
+        assertEquals(1, result[0].multimodalElements.size)
+        assertEquals("product-1", result[0].multimodalElements[0].id)
+        // CTA button should be parsed separately
+        assertNotNull(result[0].ctaButton)
+        assertEquals("Chat now", result[0].ctaButton!!.label)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton is null when no ctaButton element present`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Regular response"
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNull(result[0].ctaButton)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton is null when multimodalElements is array format`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Intermediate chunk",
+                        "multimodalElements": []
+                      },
+                      "state": "in-progress"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNull(result[0].ctaButton)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton is null when entity_info primary is missing`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Incomplete CTA",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {}
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNull(result[0].ctaButton)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton is null when primary text is empty`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "CTA missing label",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "",
+                                  "url": "https://example.com/chat"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNull(result[0].ctaButton)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton is null when primary url is empty`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "CTA missing url",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": ""
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNull(result[0].ctaButton)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton uses first ctaButton element when multiple present`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Multiple CTAs",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "cta-1",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "First CTA",
+                                  "url": "https://example.com/first"
+                                }
+                              }
+                            },
+                            {
+                              "type": "ctaButton",
+                              "id": "cta-2",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Second CTA",
+                                  "url": "https://example.com/second"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNotNull(result[0].ctaButton)
+        assertEquals("First CTA", result[0].ctaButton!!.label)
+        assertEquals("https://example.com/first", result[0].ctaButton!!.url)
+    }
+
+    @Test
+    fun `parseConversationData ctaButton falls back to root element when entity_info absent`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "CTA without entity_info",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "primary": {
+                                "text": "Chat now",
+                                "url": "https://example.com/chat"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertNotNull(result[0].ctaButton)
+        assertEquals("Chat now", result[0].ctaButton!!.label)
+        assertEquals("https://example.com/chat", result[0].ctaButton!!.url)
+    }
+
+    @Test
+    fun `parseConversationData parses ctaButton alongside product cards and sources`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "conversationId": "conv-abc",
+                      "interactionId": "inter-xyz",
+                      "response": {
+                        "message": "Here is a product [1]",
+                        "promptSuggestions": ["Tell me more"],
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "id": "prod-1",
+                              "entity_info": {
+                                "productName": "Great Product",
+                                "productImageURL": "https://example.com/img.jpg"
+                              }
+                            },
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat with us",
+                                  "url": "https://example.com/chat"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "sources": [
+                          {
+                            "title": "Product Guide",
+                            "url": "https://guide.example.com",
+                            "citation_number": 1
+                          }
+                        ]
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val message = result[0]
+        assertEquals("conv-abc", message.conversationId)
+        assertEquals(1, message.multimodalElements.size)
+        assertEquals("Great Product", message.multimodalElements[0].title)
+        assertEquals(1, message.sources.size)
+        assertEquals(1, message.promptSuggestions.size)
+        assertNotNull(message.ctaButton)
+        assertEquals("Chat with us", message.ctaButton!!.label)
+        assertEquals("https://example.com/chat", message.ctaButton!!.url)
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
@@ -2469,7 +2469,9 @@ class ConversationResponseParserTest {
         assertEquals("Chat with us", cta.button.label)
         assertEquals("https://example.com/chat", cta.button.url)
     }
-}
+
+    @Test
+    fun `parseConversationData parses CTA from type field`() {
         val json = """
             {
               "handle": [
@@ -2487,7 +2489,7 @@ class ConversationResponseParserTest {
                               "entity_info": {
                                 "primary": {
                                   "text": "Chat now",
-                                  "url": "https://www.dickssportinggoods.com/s/live-chat"
+                                  "url": "https://example.com/live-chat"
                                 }
                               }
                             }
@@ -2507,7 +2509,7 @@ class ConversationResponseParserTest {
         assertEquals(1, result[0].orderedElements.size)
         val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
         assertEquals("Chat now", cta.button.label)
-        assertEquals("https://www.dickssportinggoods.com/s/live-chat", cta.button.url)
+        assertEquals("https://example.com/live-chat", cta.button.url)
     }
 
     @Test
@@ -2529,7 +2531,7 @@ class ConversationResponseParserTest {
                               "entity_info": {
                                 "primary": {
                                   "text": "Chat now",
-                                  "url": "https://www.dickssportinggoods.com/s/live-chat"
+                                  "url": "https://example.com/live-chat"
                                 }
                               }
                             }
@@ -2563,7 +2565,7 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-primary",
                               "entity_info": {
                                 "primary": {

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/ConversationResponseParserTest.kt
@@ -2067,11 +2067,13 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "label": "Chat now",
-                                "url": "https://www.example.com/live-chat"
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://www.example.com/live-chat"
+                                }
                               }
                             }
                           ]
@@ -2114,11 +2116,13 @@ class ConversationResponseParserTest {
                               }
                             },
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "label": "Chat now",
-                                "url": "https://example.com/chat"
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://example.com/chat"
+                                }
                               }
                             }
                           ]
@@ -2206,10 +2210,12 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "url": "https://example.com/chat"
+                                "primary": {
+                                  "url": "https://example.com/chat"
+                                }
                               }
                             }
                           ]
@@ -2242,10 +2248,12 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "label": "Chat now"
+                                "primary": {
+                                  "text": "Chat now"
+                                }
                               }
                             }
                           ]
@@ -2278,18 +2286,18 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
-                              "entity_info": { "label": "Shop All", "url": "https://example.com/shop" }
+                              "entity_info": { "primary": { "text": "Shop All", "url": "https://example.com/shop" } }
                             },
                             {
                               "id": "card-1",
                               "entity_info": { "productName": "Product A" }
                             },
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-2",
-                              "entity_info": { "label": "Learn More", "url": "https://example.com/learn" }
+                              "entity_info": { "primary": { "text": "Learn More", "url": "https://example.com/learn" } }
                             }
                           ]
                         }
@@ -2327,14 +2335,14 @@ class ConversationResponseParserTest {
                         "multimodalElements": {
                           "elements": [
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
-                              "entity_info": { "label": "First", "url": "https://example.com/first" }
+                              "entity_info": { "primary": { "text": "First", "url": "https://example.com/first" } }
                             },
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-2",
-                              "entity_info": { "label": "Second", "url": "https://example.com/second" }
+                              "entity_info": { "primary": { "text": "Second", "url": "https://example.com/second" } }
                             }
                           ]
                         }
@@ -2353,44 +2361,6 @@ class ConversationResponseParserTest {
         assertEquals(2, elements.size)
         assertEquals("First", (elements[0] as ParsedMultimodalItem.Cta).button.label)
         assertEquals("Second", (elements[1] as ParsedMultimodalItem.Cta).button.label)
-    }
-
-    @Test
-    fun `parseConversationData CTA uses text field as label fallback`() {
-        val json = """
-            {
-              "handle": [
-                {
-                  "type": "brand-concierge:conversation",
-                  "payload": [
-                    {
-                      "response": {
-                        "message": "CTA text fallback",
-                        "multimodalElements": {
-                          "elements": [
-                            {
-                              "elementType": "ctaButton",
-                              "id": "cta-1",
-                              "entity_info": {
-                                "text": "Click Me",
-                                "url": "https://example.com"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "state": "completed"
-                    }
-                  ]
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val result = ConversationResponseParser.parseConversationData(json)
-        assertEquals(1, result.size)
-        val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
-        assertEquals("Click Me", cta.button.label)
     }
 
     @Test
@@ -2458,11 +2428,13 @@ class ConversationResponseParserTest {
                               }
                             },
                             {
-                              "elementType": "ctaButton",
+                              "type": "ctaButton",
                               "id": "cta-1",
                               "entity_info": {
-                                "label": "Chat with us",
-                                "url": "https://example.com/chat"
+                                "primary": {
+                                  "text": "Chat with us",
+                                  "url": "https://example.com/chat"
+                                }
                               }
                             }
                           ]
@@ -2496,6 +2468,126 @@ class ConversationResponseParserTest {
         val cta = message.orderedElements[1] as ParsedMultimodalItem.Cta
         assertEquals("Chat with us", cta.button.label)
         assertEquals("https://example.com/chat", cta.button.url)
+    }
+}
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Need help?",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://www.dickssportinggoods.com/s/live-chat"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertEquals(1, result[0].orderedElements.size)
+        val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
+        assertEquals("Chat now", cta.button.label)
+        assertEquals("https://www.dickssportinggoods.com/s/live-chat", cta.button.url)
+    }
+
+    @Test
+    fun `parseConversationData CTA with type field is excluded from multimodalElements`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "Need help?",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "type": "ctaButton",
+                              "id": "service-intent-live-chat",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Chat now",
+                                  "url": "https://www.dickssportinggoods.com/s/live-chat"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        assertTrue(result[0].multimodalElements.isEmpty())
+    }
+
+    @Test
+    fun `parseConversationData parses CTA label from entity_info primary text`() {
+        val json = """
+            {
+              "handle": [
+                {
+                  "type": "brand-concierge:conversation",
+                  "payload": [
+                    {
+                      "response": {
+                        "message": "We can help!",
+                        "multimodalElements": {
+                          "elements": [
+                            {
+                              "elementType": "ctaButton",
+                              "id": "cta-primary",
+                              "entity_info": {
+                                "primary": {
+                                  "text": "Shop Now",
+                                  "url": "https://example.com/shop"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "state": "completed"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val result = ConversationResponseParser.parseConversationData(json)
+        assertEquals(1, result.size)
+        val cta = result[0].orderedElements[0] as ParsedMultimodalItem.Cta
+        assertEquals("Shop Now", cta.button.label)
+        assertEquals("https://example.com/shop", cta.button.url)
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponseTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/network/TempConversationResponseTest.kt
@@ -65,7 +65,67 @@ class TempConversationResponseTest {
         assertEquals(null, message.interactionId)
         assertTrue(message.promptSuggestions.isEmpty())
         assertTrue(message.multimodalElements.isEmpty())
+        assertTrue(message.orderedElements.isEmpty())
         assertTrue(message.sources.isEmpty())
+    }
+
+    @Test
+    fun `CtaButton creates with label and url`() {
+        val cta = CtaButton(label = "Shop All", url = "https://example.com/shop")
+        assertEquals("Shop All", cta.label)
+        assertEquals("https://example.com/shop", cta.url)
+    }
+
+    @Test
+    fun `CtaButton equality works`() {
+        val cta1 = CtaButton(label = "Shop", url = "https://example.com")
+        val cta2 = CtaButton(label = "Shop", url = "https://example.com")
+        val cta3 = CtaButton(label = "Learn", url = "https://example.com")
+        assertEquals(cta1, cta2)
+        assertNotEquals(cta1, cta3)
+    }
+
+    @Test
+    fun `ParsedMultimodalItem Card wraps MultimodalElement`() {
+        val element = MultimodalElement(id = "card-1")
+        val item = ParsedMultimodalItem.Card(element)
+        assertEquals(element, item.element)
+        assertTrue(item is ParsedMultimodalItem)
+    }
+
+    @Test
+    fun `ParsedMultimodalItem Cta wraps CtaButton`() {
+        val cta = CtaButton(label = "Go", url = "https://example.com")
+        val item = ParsedMultimodalItem.Cta(cta)
+        assertEquals(cta, item.button)
+        assertTrue(item is ParsedMultimodalItem)
+    }
+
+    @Test
+    fun `ParsedConversationMessage orderedElements defaults to empty`() {
+        val message = ParsedConversationMessage(
+            messageContent = "Hello",
+            state = ConversationState.COMPLETED
+        )
+        assertTrue(message.orderedElements.isEmpty())
+    }
+
+    @Test
+    fun `ParsedConversationMessage creates with orderedElements`() {
+        val cta = CtaButton(label = "Learn More", url = "https://example.com")
+        val card = MultimodalElement(id = "card-1")
+        val elements = listOf(
+            ParsedMultimodalItem.Cta(cta),
+            ParsedMultimodalItem.Card(card)
+        )
+        val message = ParsedConversationMessage(
+            messageContent = "Here you go",
+            state = ConversationState.COMPLETED,
+            orderedElements = elements
+        )
+        assertEquals(2, message.orderedElements.size)
+        assertTrue(message.orderedElements[0] is ParsedMultimodalItem.Cta)
+        assertTrue(message.orderedElements[1] is ParsedMultimodalItem.Card)
     }
 
     @Test

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -28,6 +28,7 @@ import com.adobe.marketing.mobile.concierge.ui.state.ChatEvent
 import com.adobe.marketing.mobile.concierge.ui.state.ChatScreenState
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackEvent
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackType
+import com.adobe.marketing.mobile.concierge.ui.state.MessageContent
 import com.adobe.marketing.mobile.concierge.ui.state.MessageInteractionEvent
 import com.adobe.marketing.mobile.concierge.ui.state.MicEvent
 import com.adobe.marketing.mobile.concierge.ui.state.UserInputState
@@ -1212,8 +1213,8 @@ class ConciergeChatViewModelTest {
         val messages = vm.messages.value
         // user + CTA only — no empty text bubble
         assertEquals(2, messages.size)
-        assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton)
-        val cta = messages[1].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton
+        assertTrue(messages[1].content is MessageContent.CtaButton)
+        val cta = messages[1].content as MessageContent.CtaButton
         assertEquals("Chat now", cta.button.label)
     }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -1138,6 +1138,85 @@ class ConciergeChatViewModelTest {
         assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Mixed)
     }
 
+    @Test
+    fun `text message has no interactionId when orderedElements contains a CTA`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+
+        every { chatClient.chat("Connect") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "I'll connect you with an agent.",
+                state = ConversationState.COMPLETED,
+                interactionId = "interaction-123",
+                orderedElements = listOf(
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "Chat now", url = "https://example.com/chat"))
+                )
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Connect"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + CTA = 3
+        assertEquals(3, messages.size)
+        // text message must NOT have interactionId so feedback controls are suppressed
+        assertNull(messages[1].interactionId)
+        assertTrue(messages[2].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton)
+    }
+
+    @Test
+    fun `text message retains interactionId when orderedElements contains only cards`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+
+        every { chatClient.chat("Products") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Here are some products.",
+                state = ConversationState.COMPLETED,
+                interactionId = "interaction-456",
+                orderedElements = listOf(ParsedMultimodalItem.Card(MultimodalElement(id = "card-1")))
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Products"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + carousel = 3; text message retains interactionId for feedback
+        assertEquals(3, messages.size)
+        assertEquals("interaction-456", messages[1].interactionId)
+    }
+
+    @Test
+    fun `orderedElements with empty text removes placeholder and shows only CTA`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+
+        every { chatClient.chat("Chat") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "",
+                state = ConversationState.COMPLETED,
+                orderedElements = listOf(
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "Chat now", url = "https://example.com/chat"))
+                )
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Chat"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + CTA only — no empty text bubble
+        assertEquals(2, messages.size)
+        assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton)
+        val cta = messages[1].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton
+        assertEquals("Chat now", cta.button.label)
+    }
+
     // ========== Theme Config Tests ==========
 
     @Test

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -19,7 +19,9 @@ import com.adobe.marketing.mobile.concierge.network.Citation
 import com.adobe.marketing.mobile.concierge.network.ConciergeConversationServiceClient
 import com.adobe.marketing.mobile.concierge.network.ConversationState
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
+import com.adobe.marketing.mobile.concierge.network.CtaButton as NetworkCtaButton
 import com.adobe.marketing.mobile.concierge.network.ParsedConversationMessage
+import com.adobe.marketing.mobile.concierge.network.ParsedMultimodalItem
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 import com.adobe.marketing.mobile.concierge.ui.state.ChatEvent
@@ -996,6 +998,144 @@ class ConciergeChatViewModelTest {
         
         // Verify the captured feedback includes the conversationId
         assertEquals("conv-123", feedbackSlot.captured.conversationId)
+    }
+
+    // ========== Ordered Elements Tests ==========
+
+    @Test
+    fun `orderedElements with CTA appends standalone CtaButton message`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+
+        every { chatClient.chat("Go") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Tap below",
+                state = ConversationState.COMPLETED,
+                orderedElements = listOf(
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "Shop All", url = "https://example.com/shop"))
+                )
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Go"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + CTA = 3
+        assertEquals(3, messages.size)
+        assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Text)
+        assertTrue(messages[2].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton)
+        val ctaContent = messages[2].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton
+        assertEquals("Shop All", ctaContent.button.label)
+    }
+
+    @Test
+    fun `orderedElements with cards appends separate Mixed card message`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+        val card = MultimodalElement(id = "card-1")
+
+        every { chatClient.chat("Products") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Here they are",
+                state = ConversationState.COMPLETED,
+                orderedElements = listOf(ParsedMultimodalItem.Card(card))
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Products"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + carousel = 3
+        assertEquals(3, messages.size)
+        assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Text)
+        val mixed = messages[2].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Mixed
+        assertEquals(1, mixed.multimodalElements?.size)
+    }
+
+    @Test
+    fun `orderedElements interleaves CTA before cards preserving array order`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+        val card = MultimodalElement(id = "card-1")
+
+        every { chatClient.chat("Mix") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Here you go",
+                state = ConversationState.COMPLETED,
+                orderedElements = listOf(
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "Shop", url = "https://example.com")),
+                    ParsedMultimodalItem.Card(card)
+                )
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Mix"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + CTA + carousel = 4
+        assertEquals(4, messages.size)
+        assertTrue(messages[2].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton)
+        assertTrue(messages[3].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Mixed)
+    }
+
+    @Test
+    fun `multiple CTAs each produce a separate CtaButton message`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+
+        every { chatClient.chat("Options") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Choose one",
+                state = ConversationState.COMPLETED,
+                orderedElements = listOf(
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "A", url = "https://example.com/a")),
+                    ParsedMultimodalItem.Cta(NetworkCtaButton(label = "B", url = "https://example.com/b"))
+                )
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Options"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + text + CTA1 + CTA2 = 4
+        assertEquals(4, messages.size)
+        val cta1 = messages[2].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton
+        val cta2 = messages[3].content as com.adobe.marketing.mobile.concierge.ui.state.MessageContent.CtaButton
+        assertEquals("A", cta1.button.label)
+        assertEquals("B", cta2.button.label)
+    }
+
+    @Test
+    fun `empty orderedElements falls back to legacy Mixed behavior`() = runTest {
+        val fakeSpeech = FakeSpeechCapturing()
+        val chatClient = mockk<ConciergeConversationServiceClient>()
+        val elements = listOf(MultimodalElement(id = "card-1"))
+
+        every { chatClient.chat("Hello") } returns flow {
+            emit(ParsedConversationMessage(
+                messageContent = "Here are products",
+                state = ConversationState.COMPLETED,
+                multimodalElements = elements,
+                orderedElements = emptyList()
+            ))
+        }
+
+        val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
+        vm.processEvent(ChatEvent.SendMessage("Hello"))
+        advanceUntilIdle()
+
+        val messages = vm.messages.value
+        // user + Mixed = 2 (legacy path)
+        assertEquals(2, messages.size)
+        assertTrue(messages[1].content is com.adobe.marketing.mobile.concierge.ui.state.MessageContent.Mixed)
     }
 
     // ========== Theme Config Tests ==========

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenStateTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/state/ChatScreenStateTest.kt
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.concierge.ui.state
 
 import com.adobe.marketing.mobile.concierge.network.Citation
+import com.adobe.marketing.mobile.concierge.network.CtaButton as NetworkCtaButton
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
@@ -497,6 +498,38 @@ class ChatScreenStateTest {
 
         // Then
         assertEquals(unicodeText, actualText)
+    }
+
+    // ========== MessageContent.CtaButton Tests ==========
+
+    @Test
+    fun `MessageContent CtaButton creates with button`() {
+        val button = NetworkCtaButton(label = "Shop All", url = "https://example.com/shop")
+        val content = MessageContent.CtaButton(button)
+        assertEquals("Shop All", content.button.label)
+        assertEquals("https://example.com/shop", content.button.url)
+    }
+
+    @Test
+    fun `ChatMessage getText returns label from CtaButton content`() {
+        val button = NetworkCtaButton(label = "Learn More", url = "https://example.com/learn")
+        val message = ChatMessage(
+            content = MessageContent.CtaButton(button),
+            isFromUser = false,
+            timestamp = System.currentTimeMillis()
+        )
+        assertEquals("Learn More", message.text)
+    }
+
+    @Test
+    fun `MessageContent CtaButton is distinct from Text and Mixed`() {
+        val textContent = MessageContent.Text("Hello")
+        val mixedContent = MessageContent.Mixed(text = "Mixed")
+        val ctaContent = MessageContent.CtaButton(NetworkCtaButton(label = "Go", url = "https://example.com"))
+
+        assertTrue(textContent is MessageContent.Text)
+        assertTrue(mixedContent is MessageContent.Mixed)
+        assertTrue(ctaContent is MessageContent.CtaButton)
     }
 
     // ========== FeedbackType Tests ==========

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
@@ -653,6 +653,133 @@ class CSSKeyMapperTest {
     }
 
     // -----------------------------------------------------------------------
+    // Layout - CTA button
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `apply maps cta-button-border-radius`() {
+        val result = CSSKeyMapper.apply("--cta-button-border-radius", "99px", emptyTheme)
+        assertEquals(99.0, result.cssLayout?.ctaButtonBorderRadius)
+    }
+
+    @Test
+    fun `apply maps cta-button-horizontal-padding`() {
+        val result = CSSKeyMapper.apply("--cta-button-horizontal-padding", "16px", emptyTheme)
+        assertEquals(16.0, result.cssLayout?.ctaButtonHorizontalPadding)
+    }
+
+    @Test
+    fun `apply maps cta-button-vertical-padding`() {
+        val result = CSSKeyMapper.apply("--cta-button-vertical-padding", "12px", emptyTheme)
+        assertEquals(12.0, result.cssLayout?.ctaButtonVerticalPadding)
+    }
+
+    @Test
+    fun `apply maps cta-button-font-size`() {
+        val result = CSSKeyMapper.apply("--cta-button-font-size", "14px", emptyTheme)
+        assertEquals(14.0, result.cssLayout?.ctaButtonFontSize)
+    }
+
+    @Test
+    fun `apply maps cta-button-font-weight`() {
+        val result = CSSKeyMapper.apply("--cta-button-font-weight", "400", emptyTheme)
+        assertEquals(400, result.cssLayout?.ctaButtonFontWeight)
+    }
+
+    @Test
+    fun `apply maps cta-button-icon-size`() {
+        val result = CSSKeyMapper.apply("--cta-button-icon-size", "16px", emptyTheme)
+        assertEquals(16.0, result.cssLayout?.ctaButtonIconSize)
+    }
+
+    @Test
+    fun `apply maps all cta-button layout properties independently`() {
+        var theme = CSSKeyMapper.apply("--cta-button-border-radius", "24px", emptyTheme)
+        theme = CSSKeyMapper.apply("--cta-button-horizontal-padding", "20px", theme)
+        theme = CSSKeyMapper.apply("--cta-button-vertical-padding", "8px", theme)
+        theme = CSSKeyMapper.apply("--cta-button-font-size", "16px", theme)
+        theme = CSSKeyMapper.apply("--cta-button-font-weight", "700", theme)
+        theme = CSSKeyMapper.apply("--cta-button-icon-size", "18px", theme)
+        assertEquals(24.0, theme.cssLayout?.ctaButtonBorderRadius)
+        assertEquals(20.0, theme.cssLayout?.ctaButtonHorizontalPadding)
+        assertEquals(8.0, theme.cssLayout?.ctaButtonVerticalPadding)
+        assertEquals(16.0, theme.cssLayout?.ctaButtonFontSize)
+        assertEquals(700, theme.cssLayout?.ctaButtonFontWeight)
+        assertEquals(18.0, theme.cssLayout?.ctaButtonIconSize)
+    }
+
+    @Test
+    fun `apply preserves existing layout when adding cta-button layout`() {
+        val withInput = CSSKeyMapper.apply("--input-height-mobile", "52px", emptyTheme)
+        val withBoth = CSSKeyMapper.apply("--cta-button-border-radius", "99px", withInput)
+        assertEquals(52.0, withBoth.cssLayout?.inputHeight)
+        assertEquals(99.0, withBoth.cssLayout?.ctaButtonBorderRadius)
+    }
+
+    @Test
+    fun `supportedCSSKeys contains cta button layout keys`() {
+        val keys = CSSKeyMapper.supportedCSSKeys
+        assertTrue(keys.contains("cta-button-border-radius"))
+        assertTrue(keys.contains("cta-button-horizontal-padding"))
+        assertTrue(keys.contains("cta-button-vertical-padding"))
+        assertTrue(keys.contains("cta-button-font-size"))
+        assertTrue(keys.contains("cta-button-font-weight"))
+        assertTrue(keys.contains("cta-button-icon-size"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Colors - CTA button
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `apply maps cta-button-background-color`() {
+        val result = CSSKeyMapper.apply("--cta-button-background-color", "#EDEDED", emptyTheme)
+        assertNotNull(result.colors?.ctaButton?.backgroundColor)
+        assertEquals("#EDEDED", result.colors?.ctaButton?.backgroundColor)
+    }
+
+    @Test
+    fun `apply maps cta-button-text-color`() {
+        val result = CSSKeyMapper.apply("--cta-button-text-color", "#191F1C", emptyTheme)
+        assertNotNull(result.colors?.ctaButton?.textColor)
+        assertEquals("#191F1C", result.colors?.ctaButton?.textColor)
+    }
+
+    @Test
+    fun `apply maps cta-button-icon-color`() {
+        val result = CSSKeyMapper.apply("--cta-button-icon-color", "#161313", emptyTheme)
+        assertNotNull(result.colors?.ctaButton?.iconColor)
+        assertEquals("#161313", result.colors?.ctaButton?.iconColor)
+    }
+
+    @Test
+    fun `apply maps all three cta-button colors independently`() {
+        var theme = CSSKeyMapper.apply("--cta-button-background-color", "#FFFFFF", emptyTheme)
+        theme = CSSKeyMapper.apply("--cta-button-text-color", "#000000", theme)
+        theme = CSSKeyMapper.apply("--cta-button-icon-color", "#FF0000", theme)
+        assertEquals("#FFFFFF", theme.colors?.ctaButton?.backgroundColor)
+        assertEquals("#000000", theme.colors?.ctaButton?.textColor)
+        assertEquals("#FF0000", theme.colors?.ctaButton?.iconColor)
+    }
+
+    @Test
+    fun `apply preserves other cta-button colors when setting one`() {
+        val withBackground = CSSKeyMapper.apply("--cta-button-background-color", "#EDEDED", emptyTheme)
+        val withBoth = CSSKeyMapper.apply("--cta-button-text-color", "#191F1C", withBackground)
+        assertEquals("#EDEDED", withBoth.colors?.ctaButton?.backgroundColor)
+        assertEquals("#191F1C", withBoth.colors?.ctaButton?.textColor)
+        assertNull(withBoth.colors?.ctaButton?.iconColor)
+    }
+
+    @Test
+    fun `supportedCSSKeys contains cta button keys`() {
+        val keys = CSSKeyMapper.supportedCSSKeys
+        assertTrue(keys.contains("cta-button-background-color"))
+        assertTrue(keys.contains("cta-button-text-color"))
+        assertTrue(keys.contains("cta-button-icon-color"))
+    }
+
+    // -----------------------------------------------------------------------
     // Existing theme fields are preserved on incremental apply
     // -----------------------------------------------------------------------
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokensTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokensTest.kt
@@ -571,6 +571,110 @@ class ConciergeThemeTokensTest {
         assertEquals(1, tokens.cssVariables.size)
     }
 
+    // -----------------------------------------------------------------------
+    // ConciergeLayout - CTA button fields
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `ConciergeLayout cta button fields default to null`() {
+        val layout = ConciergeLayout()
+        assertNull(layout.ctaButtonBorderRadius)
+        assertNull(layout.ctaButtonHorizontalPadding)
+        assertNull(layout.ctaButtonVerticalPadding)
+        assertNull(layout.ctaButtonFontSize)
+        assertNull(layout.ctaButtonFontWeight)
+        assertNull(layout.ctaButtonIconSize)
+    }
+
+    @Test
+    fun `ConciergeLayout creates with cta button values`() {
+        val layout = ConciergeLayout(
+            ctaButtonBorderRadius = 99.0,
+            ctaButtonHorizontalPadding = 16.0,
+            ctaButtonVerticalPadding = 12.0,
+            ctaButtonFontSize = 14.0,
+            ctaButtonFontWeight = 400,
+            ctaButtonIconSize = 16.0
+        )
+        assertEquals(99.0, layout.ctaButtonBorderRadius)
+        assertEquals(16.0, layout.ctaButtonHorizontalPadding)
+        assertEquals(12.0, layout.ctaButtonVerticalPadding)
+        assertEquals(14.0, layout.ctaButtonFontSize)
+        assertEquals(400, layout.ctaButtonFontWeight)
+        assertEquals(16.0, layout.ctaButtonIconSize)
+    }
+
+    @Test
+    fun `ConciergeLayout copy preserves cta button fields`() {
+        val original = ConciergeLayout(ctaButtonBorderRadius = 99.0, ctaButtonFontSize = 14.0)
+        val updated = original.copy(ctaButtonHorizontalPadding = 20.0)
+        assertEquals(99.0, updated.ctaButtonBorderRadius)
+        assertEquals(14.0, updated.ctaButtonFontSize)
+        assertEquals(20.0, updated.ctaButtonHorizontalPadding)
+        assertNull(original.ctaButtonHorizontalPadding)
+    }
+
+    // -----------------------------------------------------------------------
+    // ConciergeCtaButtonColors
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `ConciergeCtaButtonColors creates with all nulls by default`() {
+        val colors = ConciergeCtaButtonColors()
+        assertNull(colors.backgroundColor)
+        assertNull(colors.textColor)
+        assertNull(colors.iconColor)
+    }
+
+    @Test
+    fun `ConciergeCtaButtonColors creates with custom values`() {
+        val colors = ConciergeCtaButtonColors(
+            backgroundColor = "#EDEDED",
+            textColor = "#191F1C",
+            iconColor = "#161313"
+        )
+        assertEquals("#EDEDED", colors.backgroundColor)
+        assertEquals("#191F1C", colors.textColor)
+        assertEquals("#161313", colors.iconColor)
+    }
+
+    @Test
+    fun `ConciergeCtaButtonColors supports partial construction`() {
+        val colors = ConciergeCtaButtonColors(backgroundColor = "#FFFFFF")
+        assertEquals("#FFFFFF", colors.backgroundColor)
+        assertNull(colors.textColor)
+        assertNull(colors.iconColor)
+    }
+
+    @Test
+    fun `ConciergeCtaButtonColors supports copy`() {
+        val original = ConciergeCtaButtonColors(backgroundColor = "#EDEDED")
+        val updated = original.copy(textColor = "#191F1C")
+        assertEquals("#EDEDED", updated.backgroundColor)
+        assertEquals("#191F1C", updated.textColor)
+        assertNull(updated.iconColor)
+        assertNull(original.textColor)
+    }
+
+    @Test
+    fun `ConciergeThemeColors accepts ctaButton field`() {
+        val ctaColors = ConciergeCtaButtonColors(
+            backgroundColor = "#EDEDED",
+            textColor = "#191F1C",
+            iconColor = "#161313"
+        )
+        val themeColors = ConciergeThemeColors(ctaButton = ctaColors)
+        assertEquals("#EDEDED", themeColors.ctaButton?.backgroundColor)
+        assertEquals("#191F1C", themeColors.ctaButton?.textColor)
+        assertEquals("#161313", themeColors.ctaButton?.iconColor)
+    }
+
+    @Test
+    fun `ConciergeThemeColors ctaButton defaults to null`() {
+        val themeColors = ConciergeThemeColors()
+        assertNull(themeColors.ctaButton)
+    }
+
     @Test
     fun `theme tokens support deep copy`() {
         val original = ConciergeThemeTokens(

--- a/code/testapp/src/main/assets/themeCardDemo.json
+++ b/code/testapp/src/main/assets/themeCardDemo.json
@@ -204,6 +204,15 @@
     "--product-card-text-top-padding": "24px",
     "--product-card-text-bottom-padding": "16px",
     "--product-card-carousel-horizontal-padding": "16px",
-    "--product-card-carousel-spacing": "12px"
+    "--product-card-carousel-spacing": "12px",
+    "--cta-button-background-color": "#EDEDED",
+    "--cta-button-text-color": "#191F1C",
+    "--cta-button-icon-color": "#161313",
+    "--cta-button-border-radius": "99px",
+    "--cta-button-horizontal-padding": "16px",
+    "--cta-button-vertical-padding": "12px",
+    "--cta-button-font-size": "14px",
+    "--cta-button-font-weight": "400",
+    "--cta-button-icon-size": "16px"
   }
 }

--- a/code/testapp/src/main/assets/themeDefault.json
+++ b/code/testapp/src/main/assets/themeDefault.json
@@ -196,6 +196,15 @@
     "--product-card-text-bottom-padding": "16px",
     "--product-card-text-spacing": "8px",
     "--product-card-carousel-horizontal-padding": "16px",
-    "--product-card-carousel-spacing": "12px"
+    "--product-card-carousel-spacing": "12px",
+    "--cta-button-background-color": "#EDEDED",
+    "--cta-button-text-color": "#191F1C",
+    "--cta-button-icon-color": "#161313",
+    "--cta-button-border-radius": "99px",
+    "--cta-button-horizontal-padding": "16px",
+    "--cta-button-vertical-padding": "12px",
+    "--cta-button-font-size": "14px",
+    "--cta-button-font-weight": "400",
+    "--cta-button-icon-size": "16px"
   }
 }

--- a/code/testapp/src/main/assets/themeDemo.json
+++ b/code/testapp/src/main/assets/themeDemo.json
@@ -196,6 +196,15 @@
     "--product-card-was-price-color": "#6E6E6E",
     "--product-card-was-price-font-size": "12px",
     "--product-card-was-price-font-weight": "400",
-    "--product-card-was-price-text-prefix": "was "
+    "--product-card-was-price-text-prefix": "was ",
+    "--cta-button-background-color": "#EDEDED",
+    "--cta-button-text-color": "#191F1C",
+    "--cta-button-icon-color": "#161313",
+    "--cta-button-border-radius": "99px",
+    "--cta-button-horizontal-padding": "16px",
+    "--cta-button-vertical-padding": "12px",
+    "--cta-button-font-size": "14px",
+    "--cta-button-font-weight": "400",
+    "--cta-button-icon-size": "16px"
   }
 }


### PR DESCRIPTION
## Description
Add CTA buttons with theming and ordered multimodal support. The CTA buttons will be present in this proposed json payload:
```json
{
  "message": "That's something a teammate can help with. I'll connect you.",
  "multimodalElements": {
    "elements": [
      {
        "type": "ctaButton",
        "id": "service-intent-live-chat",
        "entity_info": {
          "primary": {
            "text": "Chat now",
            "url": "shop.com/live-chat"
          }
        }
      }
    ]
  },
  "promptSuggestions": [],
  "sources": []
}
```

**Parser (`ConversationResponseParser` / `TempConversationResponse`):**
- Added `ParsedMultimodalItem` sealed class (`Card` | `Cta`) as an ordered intermediate representation
- Replaced `extractMultimodalElements` + `extractCtaButtonFromElements` with `extractOrderedElements`, which walks the `multimodalElements` array in position order and uses the new `elementType: "ctaButton"` field to distinguish CTAs from product cards
- Added `parseCtaButton` helper that resolves `label`/`url` from `entityInfo` with a fallback to the root element map
- `multimodalElements` is preserved as a derived field for backward compatibility with the legacy ViewModel path

**State (`ChatScreenState`):**
- Added `MessageContent.CtaButton(val button: NetworkCtaButton)` variant to the sealed class
- Updated `ChatMessage.text` getter to handle the new variant

**UI (`ChatMessageItem`):**
- Added `RenderCtaButton` composable that delegates to the existing service-intent `CtaButton` composable, keeping styling consistent
- Added `MessageContent.CtaButton` branch to the `when` in `ChatMessageItem`
- Removed redundant runtime type check in `RenderMixedMessage`

**ViewModel (`ConciergeChatViewModel`):**
- `replaceAssistantMessageContent` now branches on `orderedElements.isNotEmpty()` — when true it calls `appendOrderedElementMessages` after updating the text message
- `appendOrderedElementMessages` pre-collects all cards and appends them as a single batched `Mixed` message at the first `Card` position; each `Cta` becomes its own standalone `MessageContent.CtaButton` message
- Removed dead `ctaButton` parameter from `updateAssistantMessageContent`

**Preview (`OrderedElementsPreview`):**
- New `@Preview` composable covering all 9 ordered-element combinations (text only, 1 CTA, 3 CTAs, 2 cards, 3 cards, CTA+cards, cards+CTA, CTA+card+CTA, complex mixed)

- Added CTA button theming support (9 CSS variables)

| CSS variable | Parsed in | Applied via |
|---|---|---|
| `--cta-button-background-color` | `CSSKeyMapper` → `ConciergeCtaButtonColors.backgroundColor` | `ConciergeStyles.ctaButtonStyle.backgroundColor` |
| `--cta-button-text-color` | `CSSKeyMapper` → `ConciergeCtaButtonColors.textColor` | `ConciergeStyles.ctaButtonStyle.textColor` |
| `--cta-button-icon-color` | `CSSKeyMapper` → `ConciergeCtaButtonColors.iconColor` | `ConciergeStyles.ctaButtonStyle.iconColor` |
| `--cta-button-border-radius` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonBorderRadius` | `ConciergeStyles.ctaButtonStyle` (shape) |
| `--cta-button-horizontal-padding` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonHorizontalPadding` | `ConciergeStyles.ctaButtonStyle.horizontalPadding` |
| `--cta-button-vertical-padding` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonVerticalPadding` | `ConciergeStyles.ctaButtonStyle.verticalPadding` |
| `--cta-button-font-size` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonFontSize` | `ConciergeStyles.ctaButtonStyle.fontSize` |
| `--cta-button-font-weight` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonFontWeight` | `ConciergeStyles.ctaButtonStyle.fontWeight` |
| `--cta-button-icon-size` | `CSSKeyMapper` → `ConciergeLayout.ctaButtonIconSize` | `ConciergeStyles.ctaButtonStyle.iconSize` |


[Screen_recording_20260320_130855.webm](https://github.com/user-attachments/assets/a283450b-acd8-4ebe-b67d-5ccf6f6f43db)

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- Added unit tests for `ParsedMultimodalItem` and `extractOrderedElements` in `ConversationResponseParserTest`
- Added unit tests for `MessageContent.CtaButton` in `ChatScreenStateTest`
- Added unit tests for `appendOrderedElementMessages` in `ConciergeChatViewModelTest`
- Verified visually using the `OrderedElementsPreview` Compose preview covering all 9 scenarios

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
