### PR TITLE
Query Entry Enhancements: Add clear button, icon theming and suggested prompt auto-send

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -254,6 +254,7 @@ Feature toggles and interaction configuration.
 | JSON Key | Type | Default | Description |
 |----------|------|---------|-------------|
 | `behavior.input.enableVoiceInput` | `Bool` | `false` | Enable voice input button |
+| `behavior.input.sendButtonStyle` | `String` | `"default"` | Send button style: `"default"` (paper airplane icon) or `"arrow"` (filled circle with upward arrow) |
 | `behavior.input.disableMultiline` | `Bool` | `true` | Disable multiline text input |
 | `behavior.input.showAiChatIcon` | `Object?` | `null` | AI chat icon configuration |
 
@@ -285,6 +286,7 @@ Feature toggles and interaction configuration.
     },
     "input": {
       "enableVoiceInput": true,
+      "sendButtonStyle": "default",
       "disableMultiline": false,
       "showAiChatIcon": null
     },
@@ -545,7 +547,10 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | `--input-outline-color` | `colors.input.outline` | `String?` | `null` | Input border color (hex) |
 | `--input-focus-outline-color` | `colors.input.outlineFocus` | `String` | `"#1976D2"` | Focused input border color (hex) |
 | `--input-send-icon-color` | `colors.input.sendIconColor` | `String?` | `null` | Send button icon color (hex). Falls back to `onSurface` |
+| `--input-send-arrow-icon-color` | `colors.input.sendArrowIconColor` | `String?` | `null` | Arrow send button icon (arrow) color (hex). Falls back to `onPrimary`. Only used when `sendButtonStyle` is `"arrow"` |
+| `--input-send-arrow-background-color` | `colors.input.sendArrowBackgroundColor` | `String?` | `null` | Arrow send button circle background color (hex). Falls back to `sendIconColor` then `primary`. Only used when `sendButtonStyle` is `"arrow"` |
 | `--input-mic-icon-color` | `colors.input.micIconColor` | `String?` | `null` | Mic button icon color (hex). Falls back to `primary` |
+| `--input-mic-recording-icon-color` | `colors.input.micRecordingIconColor` | `String?` | `null` | Waveform animation color during voice recording (hex). Falls back to `onPrimary` |
 
 ### Colors - Circular Citations
 
@@ -704,6 +709,7 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
     },
     "input": {
       "enableVoiceInput": true,
+      "sendButtonStyle": "default",
       "disableMultiline": false,
       "showAiChatIcon": null
     },
@@ -845,7 +851,10 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
     "--input-text-color": "#000000",
     "--input-focus-outline-color": "#1976D2",
     "--input-send-icon-color": "#000000",
+    "--input-send-arrow-icon-color": "#FFFFFF",
+    "--input-send-arrow-background-color": "#1976D2",
     "--input-mic-icon-color": "#000000",
+    "--input-mic-recording-icon-color": "#FFFFFF",
     "--input-font-size": "16px",
     "--input-button-height": "32px",
     "--input-button-width": "32px",
@@ -946,6 +955,7 @@ This section documents which properties are fully implemented, partially impleme
 | `behavior.multimodalCarousel.carouselStyle` | ✅ | Switches between paged (prev/next/dots) and continuous scroll | `ProductCarousel` |
 | `behavior.productCard.cardStyle` | ✅ | Switches between action-button cards and extended product-detail cards | `RecommendationCards`, `ProductCarousel` |
 | `behavior.input.enableVoiceInput` | ✅ | Controls mic button visibility | `InputActionButtons` |
+| `behavior.input.sendButtonStyle` | ✅ | `"default"` (paper airplane) or `"arrow"` (filled circle with upward arrow) | `SendButton` |
 | `behavior.input.disableMultiline` | ⚠️ | Parsed but not implemented | - |
 | `behavior.input.showAiChatIcon` | ⚠️ | Parsed but not implemented | - |
 | `behavior.chat.messageAlignment` | ⚠️ | Parsed but not implemented | - |
@@ -1048,8 +1058,11 @@ These colors are used internally by composables but cannot be customized in them
 | `--input-text-color` | ✅ | Input field text color | `ChatTextField`, `FeedbackDialog` |
 | `--input-outline-color` | ✅ | Input field border color | `ChatInputPanel` |
 | `--input-focus-outline-color` | ✅ | Input field focused border color | `ChatInputPanel` |
-| `--input-send-icon-color` | ✅ | Send button icon color | `SendButton` |
+| `--input-send-icon-color` | ✅ | Send button icon color (default style tint) | `SendButton` |
+| `--input-send-arrow-icon-color` | ✅ | Arrow send button icon color (arrow style only) | `SendButton` |
+| `--input-send-arrow-background-color` | ✅ | Arrow send button circle background (arrow style only) | `SendButton` |
 | `--input-mic-icon-color` | ✅ | Mic button icon color | `MicButton` |
+| `--input-mic-recording-icon-color` | ✅ | Waveform animation color during recording | `MicButton`, `AnimatedAudioWave` |
 | `--citations-background-color` | ✅ | Citation pill background | `CircularCitation` |
 | `--citations-text-color` | ✅ | Citation pill (badge) text | `CircularCitation` |
 | `--feedback-icon-btn-background` | ✅ | Thumbs up/down button background | `FeedbackComponents` |
@@ -1170,6 +1183,8 @@ When creating themes for the Android SDK, focus on these **actively used** prope
 - `--input-background` / `--input-text-color` - Input field colors
 - `--input-outline-color` / `--input-focus-outline-color` - Input borders
 - `--input-send-icon-color` / `--input-mic-icon-color` - Send and mic button icon colors
+- `--input-send-arrow-icon-color` / `--input-send-arrow-background-color` - Arrow send button colors (when `sendButtonStyle` is `"arrow"`)
+- `--input-mic-recording-icon-color` - Waveform animation color during voice recording
 - `--submit-button-fill-color` / `--color-button-submit` - Submit button
 - `--disclaimer-color` / `--disclaimer-font-size` / `--disclaimer-font-weight` - Disclaimer text at bottom
 - `--citations-background-color` / `--citations-text-color` - Citation pill (badge).
@@ -1184,6 +1199,7 @@ When creating themes for the Android SDK, focus on these **actively used** prope
 
 **Essential Behavior:**
 - `behavior.input.enableVoiceInput` - Show/hide microphone button
+- `behavior.input.sendButtonStyle` - `"default"` (paper airplane) or `"arrow"` (filled circle with upward arrow)
 - `behavior.productCard.cardStyle` - Use `"productDetail"` for extended product cards (image, badge, name, subtitle, price)
 - `behavior.multimodalCarousel.carouselStyle` - Use `"paged"` for prev/next/dots or `"scroll"` for continuous scroll
 

--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -956,7 +956,7 @@ This section documents which properties are fully implemented, partially impleme
 | `behavior.productCard.cardStyle` | ✅ | Switches between action-button cards and extended product-detail cards | `RecommendationCards`, `ProductCarousel` |
 | `behavior.input.enableVoiceInput` | ✅ | Controls mic button visibility | `InputActionButtons` |
 | `behavior.input.sendButtonStyle` | ✅ | `"default"` (paper airplane) or `"arrow"` (filled circle with upward arrow) | `SendButton` |
-| `behavior.input.disableMultiline` | ⚠️ | Parsed but not implemented | - |
+| `behavior.input.disableMultiline` | ✅ | Restricts input to a single line when `true` | `ChatTextField` |
 | `behavior.input.showAiChatIcon` | ⚠️ | Parsed but not implemented | - |
 | `behavior.chat.messageAlignment` | ⚠️ | Parsed but not implemented | - |
 | `behavior.chat.messageWidth` | ⚠️ | Parsed but not implemented | - |

--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -544,6 +544,8 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | `--input-text-color` | `colors.input.text` | `String` | `"#000000"` | Input text color (hex) |
 | `--input-outline-color` | `colors.input.outline` | `String?` | `null` | Input border color (hex) |
 | `--input-focus-outline-color` | `colors.input.outlineFocus` | `String` | `"#1976D2"` | Focused input border color (hex) |
+| `--input-send-icon-color` | `colors.input.sendIconColor` | `String?` | `null` | Send button icon color (hex). Falls back to `onSurface` |
+| `--input-mic-icon-color` | `colors.input.micIconColor` | `String?` | `null` | Mic button icon color (hex). Falls back to `primary` |
 
 ### Colors - Circular Citations
 
@@ -842,6 +844,8 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
     "--input-focus-outline-width": "2px",
     "--input-text-color": "#000000",
     "--input-focus-outline-color": "#1976D2",
+    "--input-send-icon-color": "#000000",
+    "--input-mic-icon-color": "#000000",
     "--input-font-size": "16px",
     "--input-button-height": "32px",
     "--input-button-width": "32px",
@@ -1044,6 +1048,8 @@ These colors are used internally by composables but cannot be customized in them
 | `--input-text-color` | ✅ | Input field text color | `ChatTextField`, `FeedbackDialog` |
 | `--input-outline-color` | ✅ | Input field border color | `ChatInputPanel` |
 | `--input-focus-outline-color` | ✅ | Input field focused border color | `ChatInputPanel` |
+| `--input-send-icon-color` | ✅ | Send button icon color | `SendButton` |
+| `--input-mic-icon-color` | ✅ | Mic button icon color | `MicButton` |
 | `--citations-background-color` | ✅ | Citation pill background | `CircularCitation` |
 | `--citations-text-color` | ✅ | Citation pill (badge) text | `CircularCitation` |
 | `--feedback-icon-btn-background` | ✅ | Thumbs up/down button background | `FeedbackComponents` |
@@ -1163,6 +1169,7 @@ When creating themes for the Android SDK, focus on these **actively used** prope
 - `--button-secondary-border` / `--button-secondary-text` - Secondary buttons
 - `--input-background` / `--input-text-color` - Input field colors
 - `--input-outline-color` / `--input-focus-outline-color` - Input borders
+- `--input-send-icon-color` / `--input-mic-icon-color` - Send and mic button icon colors
 - `--submit-button-fill-color` / `--color-button-submit` - Submit button
 - `--disclaimer-color` / `--disclaimer-font-size` / `--disclaimer-font-weight` - Disclaimer text at bottom
 - `--citations-background-color` / `--citations-text-color` - Citation pill (badge).

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChat.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChat.kt
@@ -18,6 +18,7 @@ import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -156,6 +158,11 @@ fun ConciergeChat(
                     window.attributes.fitInsetsTypes = 0
                     window.attributes.fitInsetsSides = 0
                 }
+
+                // Resize the dialog when the keyboard appears so the
+                // header stays fixed and the weight(1f) messages area shrinks.
+                @Suppress("DEPRECATION")
+                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
                 ConciergeChat(
                     viewModel = viewModel,
@@ -356,7 +363,7 @@ internal fun ConciergeChat(
                         WelcomeCard(
                             config = welcomeConfig,
                             isReturningUser = isReturningUser,
-                            onPromptClick = { prompt -> onTextChanged(prompt) },
+                            onPromptClick = { prompt -> onEvent(ChatEvent.SendMessage(prompt)) },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp)

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -392,8 +392,8 @@ class ConciergeChatViewModel : AndroidViewModel {
      */
     private fun handlePromptSuggestionClick(suggestion: String) {
         Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "Prompt suggestion clicked: $suggestion")
-        // Set the suggestion text in the input field
-        _inputState.update { UserInputState.Editing(suggestion) }
+        // Auto-send the suggestion as a message
+        handleSendMessage(suggestion)
     }
 
     /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/AnimatedAudioWave.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/AnimatedAudioWave.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.components.input
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Animated audio waveform with 5 bars that oscillate at staggered intervals.
+ * Each bar pulses between a minimum and maximum height fraction.
+ *
+ * @param modifier Modifier for the composable
+ * @param color The color of the waveform bars
+ */
+@Composable
+internal fun AnimatedAudioWave(
+    modifier: Modifier = Modifier,
+    color: Color
+) {
+    // Base height fractions for each bar (min, max) — gives a natural waveform look
+    val barConfigs = listOf(
+        0.25f to 0.55f,   // bar 1 (short)
+        0.35f to 0.80f,   // bar 2
+        0.30f to 0.65f,   // bar 3
+        0.40f to 1.00f,   // bar 4 (tallest)
+        0.20f to 0.50f    // bar 5 (shortest)
+    )
+    val delays = listOf(0, 150, 80, 200, 120)
+
+    val transition = rememberInfiniteTransition(label = "audiowave")
+    val fractions = barConfigs.mapIndexed { index, (min, max) ->
+        transition.animateFloat(
+            initialValue = min,
+            targetValue = max,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 400, delayMillis = delays[index]),
+                repeatMode = RepeatMode.Reverse
+            ),
+            label = "bar_$index"
+        )
+    }
+
+    Canvas(modifier = modifier) {
+        val barCount = fractions.size
+        val totalWidth = size.width
+        val totalHeight = size.height
+        val barWidth = totalWidth / (barCount * 2f - 1f) // bars + gaps
+        val gap = barWidth
+        val cornerRadius = barWidth / 2f
+
+        fractions.forEachIndexed { index, anim ->
+            val fraction by anim
+            val barHeight = totalHeight * fraction
+            val x = index * (barWidth + gap)
+            val y = (totalHeight - barHeight) / 2f
+
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(x, y),
+                size = Size(barWidth, barHeight),
+                cornerRadius = CornerRadius(cornerRadius, cornerRadius)
+            )
+        }
+    }
+}

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatInputField.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatInputField.kt
@@ -115,7 +115,12 @@ internal fun ChatInputField(
                 isFocused.value = false
                 focusManager.clearFocus() // Dismiss keyboard after sending
             },
-            onVoiceCancel = onVoiceCancel
+            onVoiceCancel = onVoiceCancel,
+            onClear = {
+                text.value = ""
+                onTextChange("")
+                isFocused.value = false
+            }
         )
     }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatInputPanel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatInputPanel.kt
@@ -51,6 +51,7 @@ internal fun ChatInputPanel(
     onMicPressed: () -> Unit,
     onSend: (String) -> Unit,
     onVoiceCancel: (() -> Unit)? = null,
+    onClear: (() -> Unit)? = null,
     borderColors: List<Color> = emptyList(),
     isFocused: Boolean = false
 ) {
@@ -96,14 +97,15 @@ internal fun ChatInputPanel(
                 placeholder = if (inputState is UserInputState.Recording) style.listeningPlaceholderText else placeholder
             )
 
-            // Input action buttons (mic and send) with state-aware animations
+            // Input action buttons (clear, mic, and send) with state-aware animations
             InputActionButtons(
                 inputState = inputState,
                 text = text,
                 isProcessing = isProcessing,
                 onMicPressed = onMicPressed,
                 onVoiceCancel = { onVoiceCancel?.invoke() },
-                onSend = onSend
+                onSend = onSend,
+                onClear = { onClear?.invoke() }
             )
         }
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatTextField.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/ChatTextField.kt
@@ -50,6 +50,7 @@ internal fun ChatTextField(
     val style = ConciergeStyles.chatTextFieldStyle
     val textColor = ConciergeTheme.colors.onSurface
     val focusManager = LocalFocusManager.current
+    val disableMultiline = ConciergeTheme.behavior?.disableMultiline ?: false
 
     OutlinedTextField(
         value = value,
@@ -65,8 +66,8 @@ internal fun ChatTextField(
             )
         },
         enabled = isEnabled,
-        singleLine = false,
-        maxLines = style.maxLines,
+        singleLine = disableMultiline,
+        maxLines = if (disableMultiline) 1 else style.maxLines,
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
             imeAction = ImeAction.Done

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/InputActionButtons.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/InputActionButtons.kt
@@ -25,10 +25,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.adobe.marketing.mobile.concierge.R
 import com.adobe.marketing.mobile.concierge.ui.state.UserInputState
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
@@ -44,6 +48,7 @@ import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
  * @param onMicPressed Callback when microphone button is pressed (to start recording)
  * @param onVoiceCancel Callback when recording should be stopped
  * @param onSend Callback when send button is pressed
+ * @param onClear Callback when clear button is pressed to clear the input text
  */
 @Composable
 internal fun InputActionButtons(
@@ -53,7 +58,8 @@ internal fun InputActionButtons(
     isProcessing: Boolean,
     onMicPressed: () -> Unit,
     onVoiceCancel: () -> Unit,
-    onSend: (String) -> Unit
+    onSend: (String) -> Unit,
+    onClear: () -> Unit = {}
 ) {
     val micButtonStyle = ConciergeStyles.micButtonStyle
     val sendButtonStyle = ConciergeStyles.sendButtonStyle
@@ -70,20 +76,36 @@ internal fun InputActionButtons(
         verticalAlignment = Alignment.CenterVertically
     ) {
         val micContainerSize = micButtonStyle.size * micButtonStyle.pulseScaleRange.second
+        val hasText = text.isNotBlank()
 
         if (enableVoiceInput) {
-            MicButton(
-                modifier = Modifier.size(micContainerSize),
-                userInputState = inputState,
-                isEnabled = true,
-                onClick = {
-                    if (inputState is UserInputState.Recording) {
-                        onVoiceCancel()
-                    } else {
-                        onMicPressed()
-                    }
+            // Show clear button OR mic button
+            if (hasText && inputState !is UserInputState.Recording) {
+                IconButton(
+                    onClick = onClear,
+                    modifier = Modifier.size(micContainerSize)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.close),
+                        contentDescription = "Clear input",
+                        modifier = Modifier.size(16.dp),
+                        tint = sendButtonStyle.enabledIconColor.copy(alpha = 0.5f)
+                    )
                 }
-            )
+            } else {
+                MicButton(
+                    modifier = Modifier.size(micContainerSize),
+                    userInputState = inputState,
+                    isEnabled = true,
+                    onClick = {
+                        if (inputState is UserInputState.Recording) {
+                            onVoiceCancel()
+                        } else {
+                            onMicPressed()
+                        }
+                    }
+                )
+            }
         }
 
         // Send button - only visible when not recording.

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
@@ -101,17 +101,18 @@ internal fun MicButton(
             val baseIconColor = if (userInputState is UserInputState.Recording) style.recordingIconColor else style.iconColor
             val tintColor = if (isEnabled) baseIconColor else baseIconColor.copy(alpha = 0.38f)
 
-            Image(
-                painter = painterResource(
-                    if (userInputState is UserInputState.Recording) R.drawable.audiowave
-                    else R.drawable.microphone
-                ),
-                contentDescription = when (userInputState) {
-                    is UserInputState.Recording -> "Stop recording"
-                    else -> "Start voice input"
-                },
-                colorFilter = ColorFilter.tint(tintColor)
-            )
+            if (userInputState is UserInputState.Recording) {
+                AnimatedAudioWave(
+                    modifier = Modifier.size(style.size),
+                    color = tintColor
+                )
+            } else {
+                Image(
+                    painter = painterResource(R.drawable.microphone),
+                    contentDescription = "Start voice input",
+                    colorFilter = ColorFilter.tint(tintColor)
+                )
+            }
         }
     }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
@@ -102,7 +102,10 @@ internal fun MicButton(
             val tintColor = if (isEnabled) baseIconColor else baseIconColor.copy(alpha = 0.38f)
 
             Image(
-                painter = painterResource(R.drawable.microphone),
+                painter = painterResource(
+                    if (userInputState is UserInputState.Recording) R.drawable.audiowave
+                    else R.drawable.microphone
+                ),
                 contentDescription = when (userInputState) {
                     is UserInputState.Recording -> "Stop recording"
                     else -> "Start voice input"

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/MicButton.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import com.adobe.marketing.mobile.concierge.R
 import com.adobe.marketing.mobile.concierge.ui.state.UserInputState
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
@@ -89,19 +91,22 @@ internal fun MicButton(
             )
         }
 
+        val isRecording = userInputState is UserInputState.Recording
         IconButton(
             onClick = {
                 if (isEnabled) {
                     onClick()
                 }
             },
-            modifier = Modifier.size(style.size)
+            modifier = Modifier
+                .size(style.size)
+                .semantics { contentDescription = if (isRecording) "Stop recording" else "Start voice input" }
         ) {
             // Choose icon tint based on state and enabled flag
-            val baseIconColor = if (userInputState is UserInputState.Recording) style.recordingIconColor else style.iconColor
+            val baseIconColor = if (isRecording) style.recordingIconColor else style.iconColor
             val tintColor = if (isEnabled) baseIconColor else baseIconColor.copy(alpha = 0.38f)
 
-            if (userInputState is UserInputState.Recording) {
+            if (isRecording) {
                 AnimatedAudioWave(
                     modifier = Modifier.size(style.size),
                     color = tintColor
@@ -109,7 +114,7 @@ internal fun MicButton(
             } else {
                 Image(
                     painter = painterResource(R.drawable.microphone),
-                    contentDescription = "Start voice input",
+                    contentDescription = null,
                     colorFilter = ColorFilter.tint(tintColor)
                 )
             }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/SendButton.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/input/SendButton.kt
@@ -13,19 +13,30 @@
 package com.adobe.marketing.mobile.concierge.ui.components.input
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.R
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 
 /**
  * A send button for submitting chat messages.
+ * Supports two styles controlled via theme behavior:
+ * - "default": paper airplane icon with color tint (original look)
+ * - "arrow": filled circle with upward arrow icon
  *
  * @param modifier Modifier for the composable
- * @param canSendMessage Whether a message can be sent
  * @param isEnabled Whether the button is enabled
  * @param onSend Callback when the send button is pressed
  */
@@ -37,12 +48,39 @@ internal fun SendButton(
 ) {
     val style = ConciergeStyles.sendButtonStyle
 
+    if (style.useArrowStyle) {
+        SendButtonArrow(
+            modifier = modifier,
+            isEnabled = isEnabled,
+            circleColor = style.arrowCircleColor,
+            arrowColor = style.arrowIconColor,
+            disabledAlpha = style.disabledIconAlpha,
+            onSend = onSend
+        )
+    } else {
+        SendButtonDefault(
+            modifier = modifier,
+            isEnabled = isEnabled,
+            iconColor = style.enabledIconColor,
+            disabledAlpha = style.disabledIconAlpha,
+            onSend = onSend
+        )
+    }
+}
+
+/**
+ * Default send button — paper airplane icon with color tint.
+ */
+@Composable
+private fun SendButtonDefault(
+    modifier: Modifier,
+    isEnabled: Boolean,
+    iconColor: Color,
+    disabledAlpha: Float,
+    onSend: () -> Unit
+) {
     IconButton(
-        onClick = {
-            if (isEnabled) {
-                onSend()
-            }
-        },
+        onClick = { if (isEnabled) onSend() },
         enabled = isEnabled,
         modifier = modifier
     ) {
@@ -50,12 +88,42 @@ internal fun SendButton(
             painter = painterResource(R.drawable.send),
             contentDescription = "Send message",
             colorFilter = ColorFilter.tint(
-                if (isEnabled) {
-                    style.enabledIconColor
-                } else {
-                    style.enabledIconColor.copy(alpha = style.disabledIconAlpha)
-                }
+                if (isEnabled) iconColor
+                else iconColor.copy(alpha = disabledAlpha)
             )
+        )
+    }
+}
+
+/**
+ * Arrow send button — filled circle with upward arrow icon.
+ */
+@Composable
+private fun SendButtonArrow(
+    modifier: Modifier,
+    isEnabled: Boolean,
+    circleColor: Color,
+    arrowColor: Color,
+    disabledAlpha: Float,
+    onSend: () -> Unit
+) {
+    val bgColor = if (isEnabled) circleColor else circleColor.copy(alpha = disabledAlpha)
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(bgColor)
+            .then(
+                if (isEnabled) Modifier.clickable { onSend() }
+                else Modifier
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(R.drawable.send_arrow),
+            contentDescription = "Send message",
+            modifier = Modifier.size(14.dp),
+            colorFilter = ColorFilter.tint(arrowColor)
         )
     }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -327,7 +327,17 @@ internal object CSSKeyMapper {
                 existing?.copy(outlineFocus = color) ?: ConciergeInputColors(outlineFocus = color)
             }
         },
-        
+        "input-send-icon-color" to { cssValue, theme ->
+            updateInputColors(cssValue, theme) { existing, color ->
+                existing?.copy(sendIconColor = color) ?: ConciergeInputColors(sendIconColor = color)
+            }
+        },
+        "input-mic-icon-color" to { cssValue, theme ->
+            updateInputColors(cssValue, theme) { existing, color ->
+                existing?.copy(micIconColor = color) ?: ConciergeInputColors(micIconColor = color)
+            }
+        },
+
         // Colors - Feedback (using helper)
         "feedback-icon-btn-background" to { cssValue, theme ->
             updateFeedbackColors(cssValue, theme) { existing, color ->

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -332,9 +332,24 @@ internal object CSSKeyMapper {
                 existing?.copy(sendIconColor = color) ?: ConciergeInputColors(sendIconColor = color)
             }
         },
+        "input-send-arrow-icon-color" to { cssValue, theme ->
+            updateInputColors(cssValue, theme) { existing, color ->
+                existing?.copy(sendArrowIconColor = color) ?: ConciergeInputColors(sendArrowIconColor = color)
+            }
+        },
+        "input-send-arrow-background-color" to { cssValue, theme ->
+            updateInputColors(cssValue, theme) { existing, color ->
+                existing?.copy(sendArrowBackgroundColor = color) ?: ConciergeInputColors(sendArrowBackgroundColor = color)
+            }
+        },
         "input-mic-icon-color" to { cssValue, theme ->
             updateInputColors(cssValue, theme) { existing, color ->
                 existing?.copy(micIconColor = color) ?: ConciergeInputColors(micIconColor = color)
+            }
+        },
+        "input-mic-recording-icon-color" to { cssValue, theme ->
+            updateInputColors(cssValue, theme) { existing, color ->
+                existing?.copy(micRecordingIconColor = color) ?: ConciergeInputColors(micRecordingIconColor = color)
             }
         },
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -65,7 +65,10 @@ data class ConciergeColors(
     val inputOutlineFocus: Color? = null,
     val micButtonColor: Color? = null,
     val sendIconColor: Color? = null,
+    val sendArrowIconColor: Color? = null,
+    val sendArrowBackgroundColor: Color? = null,
     val micIconColor: Color? = null,
+    val micRecordingIconColor: Color? = null,
 
     // Feedback-specific colors (from CSS themes)
     val feedbackIconButtonBackground: Color? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -64,6 +64,8 @@ data class ConciergeColors(
     val inputOutline: Color? = null,
     val inputOutlineFocus: Color? = null,
     val micButtonColor: Color? = null,
+    val sendIconColor: Color? = null,
+    val micIconColor: Color? = null,
 
     // Feedback-specific colors (from CSS themes)
     val feedbackIconButtonBackground: Color? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -913,7 +913,7 @@ internal object ConciergeStyles {
             val fontSize = themeTypography?.inputFontSize?.sp
             return ChatTextFieldStyle(
                 horizontalPadding = 8.dp,
-                maxLines = 7,
+                maxLines = 15,
                 textStyle = MaterialTheme.typography.bodyLarge.copy(
                     color = themeColors.inputText ?: themeColors.onSurface,
                     fontSize = fontSize ?: MaterialTheme.typography.bodyLarge.fontSize

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -773,7 +773,7 @@ internal object ConciergeStyles {
             return MicButtonStyle(
                 size = 24.dp,
                 iconColor = micIconColor,
-                recordingIconColor = themeColors.onPrimary,
+                recordingIconColor = themeColors.micRecordingIconColor ?: themeColors.onPrimary,
                 pulsingBackgroundColor = micColor,
                 pulsingBackgroundAlpha = 0.25f,
                 pulseAnimationDuration = 1000,
@@ -789,16 +789,23 @@ internal object ConciergeStyles {
     data class SendButtonStyle(
         val size: Dp,
         val enabledIconColor: Color,
-        val disabledIconAlpha: Float
+        val arrowCircleColor: Color,
+        val arrowIconColor: Color,
+        val disabledIconAlpha: Float,
+        val useArrowStyle: Boolean
     )
 
     val sendButtonStyle: SendButtonStyle
         @Composable get() {
             val themeColors = ConciergeTheme.colors
+            val sendButtonStyleName = ConciergeTheme.behavior?.sendButtonStyle ?: "default"
             return SendButtonStyle(
                 size = 24.dp,
                 enabledIconColor = themeColors.sendIconColor ?: themeColors.onSurface,
-                disabledIconAlpha = 0.3f
+                arrowCircleColor = themeColors.sendArrowBackgroundColor ?: themeColors.sendIconColor ?: themeColors.primary,
+                arrowIconColor = themeColors.sendArrowIconColor ?: themeColors.onPrimary,
+                disabledIconAlpha = 0.3f,
+                useArrowStyle = sendButtonStyleName == "arrow"
             )
         }
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -769,10 +769,11 @@ internal object ConciergeStyles {
         @Composable get() {
             val themeColors = ConciergeTheme.colors
             val micColor = themeColors.primary
+            val micIconColor = themeColors.micIconColor ?: micColor
             return MicButtonStyle(
                 size = 24.dp,
-                iconColor = micColor,
-                recordingIconColor = micColor,
+                iconColor = micIconColor,
+                recordingIconColor = themeColors.onPrimary,
                 pulsingBackgroundColor = micColor,
                 pulsingBackgroundAlpha = 0.25f,
                 pulseAnimationDuration = 1000,
@@ -796,7 +797,7 @@ internal object ConciergeStyles {
             val themeColors = ConciergeTheme.colors
             return SendButtonStyle(
                 size = 24.dp,
-                enabledIconColor = themeColors.onSurface,
+                enabledIconColor = themeColors.sendIconColor ?: themeColors.onSurface,
                 disabledIconAlpha = 0.3f
             )
         }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -186,7 +186,9 @@ data class ConciergeInputColors(
     val background: String? = null,
     val text: String? = null,
     val outline: String? = null,
-    val outlineFocus: String? = null
+    val outlineFocus: String? = null,
+    val sendIconColor: String? = null,
+    val micIconColor: String? = null
 )
 
 data class ConciergeFeedbackColors(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -188,7 +188,10 @@ data class ConciergeInputColors(
     val outline: String? = null,
     val outlineFocus: String? = null,
     val sendIconColor: String? = null,
-    val micIconColor: String? = null
+    val sendArrowIconColor: String? = null,
+    val sendArrowBackgroundColor: String? = null,
+    val micIconColor: String? = null,
+    val micRecordingIconColor: String? = null
 )
 
 data class ConciergeFeedbackColors(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -157,6 +157,7 @@ data class ConciergeThemeBehavior(
     val enableMarkdown: Boolean = true,
     val enableCitations: Boolean = true,
     val enableVoiceInput: Boolean = true,
+    val sendButtonStyle: String = "default",
     val maxMessageLength: Int = 2000,
     val typingIndicatorDelay: Int = 500,
     val productCard: ConciergeProductCardBehavior? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -157,6 +157,7 @@ data class ConciergeThemeBehavior(
     val enableMarkdown: Boolean = true,
     val enableCitations: Boolean = true,
     val enableVoiceInput: Boolean = true,
+    val disableMultiline: Boolean = false,
     val sendButtonStyle: String = "default",
     val maxMessageLength: Int = 2000,
     val typingIndicatorDelay: Int = 500,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -318,6 +318,8 @@ internal object ThemeParser {
             inputOutline = themeColors.input?.outline?.toComposeColor(),
             inputOutlineFocus = themeColors.input?.outlineFocus?.toComposeColor(),
             micButtonColor = themeColors.primaryColors?.text?.toComposeColor() ?: defaultColors.micButtonColor,
+            sendIconColor = themeColors.input?.sendIconColor?.toComposeColor(),
+            micIconColor = themeColors.input?.micIconColor?.toComposeColor(),
             // Feedback-specific colors from CSS themes
             feedbackIconButtonBackground = themeColors.feedback?.iconButtonBackground?.toComposeColor(),
             feedbackIconButtonHoverBackground = themeColors.feedback?.iconButtonHoverBackground?.toComposeColor(),

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -367,6 +367,7 @@ internal object ThemeParser {
             // Default to false if not specified
             false
         }
+        val disableMultiline = DataReader.optBoolean(inputTypedMap, "disableMultiline", false)
         
         val productCardMap = typedMap?.get("productCard") as? Map<*, *>
         @Suppress("UNCHECKED_CAST")
@@ -396,6 +397,7 @@ internal object ThemeParser {
             enableMarkdown = DataReader.optBoolean(typedMap, "enableMarkdown", true),
             enableCitations = DataReader.optBoolean(typedMap, "enableCitations", true),
             enableVoiceInput = enableVoiceInput,
+            disableMultiline = disableMultiline,
             sendButtonStyle = DataReader.optString(inputTypedMap, "sendButtonStyle", "default") ?: "default",
             maxMessageLength = DataReader.optInt(typedMap, "maxMessageLength", 2000),
             typingIndicatorDelay = DataReader.optInt(typedMap, "typingIndicatorDelay", 500),

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -319,7 +319,10 @@ internal object ThemeParser {
             inputOutlineFocus = themeColors.input?.outlineFocus?.toComposeColor(),
             micButtonColor = themeColors.primaryColors?.text?.toComposeColor() ?: defaultColors.micButtonColor,
             sendIconColor = themeColors.input?.sendIconColor?.toComposeColor(),
+            sendArrowIconColor = themeColors.input?.sendArrowIconColor?.toComposeColor(),
+            sendArrowBackgroundColor = themeColors.input?.sendArrowBackgroundColor?.toComposeColor(),
             micIconColor = themeColors.input?.micIconColor?.toComposeColor(),
+            micRecordingIconColor = themeColors.input?.micRecordingIconColor?.toComposeColor(),
             // Feedback-specific colors from CSS themes
             feedbackIconButtonBackground = themeColors.feedback?.iconButtonBackground?.toComposeColor(),
             feedbackIconButtonHoverBackground = themeColors.feedback?.iconButtonHoverBackground?.toComposeColor(),
@@ -356,9 +359,9 @@ internal object ThemeParser {
         @Suppress("UNCHECKED_CAST")
         val typedMap = map as? MutableMap<String?, Any?>
         val inputMap = typedMap?.get("input") as? Map<*, *>
-        val enableVoiceInput = if (inputMap != null) {
-            @Suppress("UNCHECKED_CAST")
-            val inputTypedMap = inputMap as? MutableMap<String?, Any?>
+        @Suppress("UNCHECKED_CAST")
+        val inputTypedMap = inputMap as? MutableMap<String?, Any?>
+        val enableVoiceInput = if (inputTypedMap != null) {
             DataReader.optBoolean(inputTypedMap, "enableVoiceInput", true)
         } else {
             // Default to false if not specified
@@ -393,6 +396,7 @@ internal object ThemeParser {
             enableMarkdown = DataReader.optBoolean(typedMap, "enableMarkdown", true),
             enableCitations = DataReader.optBoolean(typedMap, "enableCitations", true),
             enableVoiceInput = enableVoiceInput,
+            sendButtonStyle = DataReader.optString(inputTypedMap, "sendButtonStyle", "default") ?: "default",
             maxMessageLength = DataReader.optInt(typedMap, "maxMessageLength", 2000),
             typingIndicatorDelay = DataReader.optInt(typedMap, "typingIndicatorDelay", 500),
             productCard = productCard,

--- a/code/concierge/src/main/res/drawable/audiowave.xml
+++ b/code/concierge/src/main/res/drawable/audiowave.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2025 Adobe. All rights reserved.
+    Copyright 2026 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License. You may obtain a copy
     of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/concierge/src/main/res/drawable/send_arrow.xml
+++ b/code/concierge/src/main/res/drawable/send_arrow.xml
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright 2026 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <!-- Upward arrow icon -->
+  <path
+      android:pathData="M10,4.5L5.5,9l1.2,1.2L9,7.9V16h2V7.9l2.3,2.3L14.5,9z"
+      android:fillColor="#222"/>
+</vector>

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -801,16 +801,20 @@ class ConciergeChatViewModelTest {
     // ========== Prompt Suggestion Tests ==========
 
     @Test
-    fun `promptSuggestionClick sets text in input field`() = runTest {
+    fun `promptSuggestionClick auto-sends message`() = runTest {
         val fakeSpeech = FakeSpeechCapturing()
         val chatClient = mockk<ConciergeConversationServiceClient>(relaxed = true)
-        
+
         val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
-        
+
         vm.processEvent(MessageInteractionEvent.PromptSuggestionClick("What can you do?"))
-        
-        val inputState = vm.inputState.value as UserInputState.Editing
-        assertEquals("What can you do?", inputState.content)
+
+        // Prompt suggestion should auto-send, so input should be empty and message added
+        assertEquals(UserInputState.Empty, vm.inputState.value)
+        val messages = vm.messages.value
+        assertTrue(messages.isNotEmpty())
+        val userMessage = messages.first()
+        assertTrue(userMessage.isFromUser)
     }
 
     // ========== Text Input State Tests ==========

--- a/code/testapp/src/main/assets/themeDefault.json
+++ b/code/testapp/src/main/assets/themeDefault.json
@@ -131,6 +131,7 @@
     "--input-button-width": "32px",
     "--input-send-icon-color": "#EB1000",
     "--input-mic-icon-color": "#EB1000",
+    "--input-mic-recording-icon-color" : "#FFFFFF",
     "--submit-button-fill-color": "#FFFFFF",
     "--submit-button-fill-color-disabled": "#C6C6C6",
     "--color-button-submit": "#292929",

--- a/code/testapp/src/main/assets/themeDefault.json
+++ b/code/testapp/src/main/assets/themeDefault.json
@@ -129,6 +129,8 @@
     "--input-text-color": "#292929",
     "--input-button-height": "32px",
     "--input-button-width": "32px",
+    "--input-send-icon-color": "#EB1000",
+    "--input-mic-icon-color": "#EB1000",
     "--submit-button-fill-color": "#FFFFFF",
     "--submit-button-fill-color-disabled": "#C6C6C6",
     "--color-button-submit": "#292929",

--- a/code/testapp/src/main/assets/themeDemo.json
+++ b/code/testapp/src/main/assets/themeDemo.json
@@ -12,7 +12,8 @@
     "input": {
       "enableVoiceInput": true,
       "disableMultiline": true,
-      "showAiChatIcon": null
+      "showAiChatIcon": null,
+      "sendButtonStyle": "arrow"
     },
     "chat": {
       "messageAlignment": "left",
@@ -161,6 +162,9 @@
     "--input-button-border-radius": "8px",
     "--input-send-icon-color": "#FFFFFF",
     "--input-mic-icon-color": "#FFFFFF",
+    "--input-mic-recording-icon-color" : "#FFFFFF",
+    "--input-send-arrow-icon-color": "#FFFFFF",
+    "--input-send-arrow-background-color": "#1E40AF",
 
     "--citations-text-font-weight": "700",
     "--citations-desktop-button-font-size": "14px",

--- a/code/testapp/src/main/assets/themeDemo.json
+++ b/code/testapp/src/main/assets/themeDemo.json
@@ -159,6 +159,8 @@
     "--input-button-height": "32px",
     "--input-button-width": "32px",
     "--input-button-border-radius": "8px",
+    "--input-send-icon-color": "#FFFFFF",
+    "--input-mic-icon-color": "#FFFFFF",
 
     "--citations-text-font-weight": "700",
     "--citations-desktop-button-font-size": "14px",


### PR DESCRIPTION
## Description

Fix and enhance input bar and prompt suggestions in the Concierge chat UI:

1. **Prompt suggestions now auto-send** — Tapping a welcome card or in-conversation prompt suggestion immediately sends the message instead of just populating the input field.
2. **Clear button replaces mic icon** — When text is present in the input field, the mic button is replaced by a clear (X) button. Only one is displayed at a time. Tapping clear resets the input.
3. **Send and mic icon colors are theme-configurable** — New CSS keys `--input-send-icon-color` and `--input-mic-icon-color` allow brand customization of the send and mic button icons via theme JSON. Falls back to `onSurface` and `primary` respectively.
4. **Audiowave icon during recording** — The mic button now switches from the microphone icon to the audiowave icon during voice recording, with a contrasting `onPrimary` tint for visibility against the pulsing background.
5. **Keyboard no longer pushes the header** — The dialog window uses `SOFT_INPUT_ADJUST_RESIZE` so the system resizes (not pans) the dialog when the keyboard appears. The `weight(1f)` messages area absorbs the height change while the header stays fixed.

## Related Issue

## Motivation and Context
The Concierge chat UI had several query entry UX issues flagged during design QA: prompt suggestions required an extra tap to send, there was no way to clear input text, send/mic button icon colors were not brand-configurable, the voice recording waveform icon was not displayed, and the header shifted when the keyboard appeared.

## How Has This Been Tested?
- Existing unit tests updated and passing (`ConciergeChatViewModelTest` — prompt suggestion auto-send test)
- Full `testPhoneDebugUnitTest` suite passes
- Manual testing on Android device:
  - Welcome card prompt tap sends message immediately
  - In-conversation suggestion tap sends message immediately
  - Clear button appears when text is entered, mic button reappears when cleared
  - Audiowave icon visible during voice recording with customizable color
  - Send/mic icon colors respond to `--input-send-icon-color` / `--input-mic-icon-color` in theme JSON
  - Header remains fixed when keyboard opens/closes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

### Files Changed

**Prompt suggestion auto-send:**
- `ConciergeChat.kt` — welcome card `onPromptClick` calls `onEvent(ChatEvent.SendMessage(prompt))` instead of `onTextChanged(prompt)`
- `ConciergeChatViewModel.kt` — `handlePromptSuggestionClick()` calls `handleSendMessage()` instead of setting `UserInputState.Editing`

**Input bar behavior:**
- `InputActionButtons.kt` — clear button replaces mic button slot when text is present; added `onClear` callback
- `ChatInputPanel.kt` — wires `onClear` to `InputActionButtons`
- `ChatInputField.kt` — wires `onClear` to clear local text state
- `MicButton.kt` — switches to audiowave icon during recording

**Keyboard / dialog:**
- `ConciergeChat.kt` — dialog window uses `SOFT_INPUT_ADJUST_RESIZE` to keep header fixed

**Theme support:**
- `ConciergeThemeModels.kt` — added `sendIconColor`, `micIconColor` to `ConciergeInputColors`
- `CSSKeyMapper.kt` — added `input-send-icon-color`, `input-mic-icon-color` mappings
- `ConciergeColors.kt` — added `sendIconColor`, `micIconColor` fields
- `ThemeParser.kt` — wires new color tokens from theme JSON
- `ConciergeStyles.kt` — `sendButtonStyle` and `micButtonStyle` read from theme colors; recording icon uses `onPrimary`

**Documentation & tests:**
- `Documentation/style-guide.md` — added new CSS keys to style guide
- `ConciergeChatViewModelTest.kt` — updated prompt suggestion test for auto-send behavior
- `themeDefault.json`, `themeDemo.json` — added new icon color keys to test themes
