### PR TITLE
Add prompt suggestions customization

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -294,6 +294,14 @@ Feature toggles and interaction configuration.
 | `behavior.welcomeCard.promptMaxLines` | number | `—` | Max lines for prompt text. When omitted, the Android SDK applies no limit. Set to `1` for uniform pill heights with ellipsis. |
 | `behavior.welcomeCard.contentAlignment` | string | `"top"` | Welcome card vertical position: `"top"` (anchored to top) or `"center"` (vertically centered) |
 
+### Prompt Suggestions
+
+| JSON Key | Type | Default | Description |
+|----------|------|---------|-------------|
+| `behavior.promptSuggestions.itemMaxLines` | number | `1` | Max lines for suggestion chip text before ellipsis. |
+| `behavior.promptSuggestions.showHeader` | boolean | `false` | Show a "Suggestions" header label above the chips. Label text is configurable via `text["suggestions.header"]`. |
+| `behavior.promptSuggestions.alignToMessage` | boolean | `false` | Align the suggestion chips to the message bubble edges. When `false`, uses the default offset. |
+
 > **Tip:** To hide the header subtitle, set `text["header.subtitle"]` to `""`. The subtitle is automatically hidden when its text is blank.
 
 ### Example
@@ -334,6 +342,11 @@ Feature toggles and interaction configuration.
       "promptFullWidth": false,
       "promptMaxLines": 1,
       "contentAlignment": "top"
+    },
+    "promptSuggestions": {
+      "itemMaxLines": 1,
+      "showHeader": true,
+      "alignToMessage": true
     }
   }
 }
@@ -443,6 +456,12 @@ While there are no strict requirements for character limits in many of these tex
 | `text["sourcesLabel"]` | `"Sources"` | Accordion label for the sources/feedback section |
 | `text["feedbackHelpfulLabel"]` | `"Was this helpful?"` | Label shown above feedback thumbs when `behavior.feedback.thumbsPlacement` is `"below"`. Set to `""` to hide. |
 
+### Prompt Suggestions
+
+| JSON Key | Default | Description |
+|----------|---------|-------------|
+| `text["suggestions.header"]` | `"Suggestions"` | Header label shown above prompt suggestion chips when `behavior.promptSuggestions.showHeader` is `true`. |
+
 ### Example
 
 ```json
@@ -455,6 +474,7 @@ While there are no strict requirements for character limits in many of these tex
     "loading.message": "Generating response from our knowledge base...",
     "feedbackHelpfulLabel": "Was this helpful?",
     "sourcesLabel": "Sources & Feedback",
+    "suggestions.header": "Suggestions",
     "feedback.dialog.title.positive": "Your feedback is appreciated",
     "feedback.dialog.title.negative": "Your feedback is appreciated",
     "feedback.dialog.question.positive": "What went well? Select all that apply.",
@@ -565,6 +585,7 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 |--------------|-----------------|------|---------|-------------|
 | `--color-primary` | `colors.primaryColors.primary` | `String` | `"#1976D2"` | Primary brand color (hex) |
 | `--color-text` | `colors.primaryColors.text` | `String` | `"#000000"` | Primary text color (hex) |
+| `--color-container` | `colors.container` | `String?` | `null` (falls back to hardcoded light/dark value) | Background for cards and container elements — prompt suggestion chips, product cards, message bubble fallback (hex) |
 
 ### Colors - Surface
 
@@ -624,6 +645,13 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 |--------------|-----------------|------|---------|-------------|
 | `--welcome-prompt-background-color` | `colors.welcomePrompt.backgroundColor` | `String?` | `null` (falls back to surface) | Prompt pill background color (hex). Only applied if a per-prompt `backgroundColor` is not defined in the prompt configuration. |
 | `--welcome-prompt-text-color` | `colors.welcomePrompt.textColor` | `String?` | `null` (falls back to `onSurface`) | Prompt pill text color (hex) |
+
+### Colors - Prompt Suggestions
+
+| CSS Variable | Kotlin Property | Type | Default | Description |
+|--------------|-----------------|------|---------|-------------|
+| `--suggestion-background-color` | `colors.promptSuggestion.backgroundColor` | `String?` | `null` (falls back to `--color-container` then hardcoded light/dark value) | Prompt suggestion chip background color (hex) |
+| `--suggestion-text-color` | `colors.promptSuggestion.textColor` | `String?` | `null` (falls back to `--message-concierge-text` then `onSurface`) | Prompt suggestion chip text and icon color (hex) |
 
 ### Colors - Circular Citations
 
@@ -775,6 +803,7 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
 | `--welcome-prompts-top-spacing` | `cssLayout.welcomePromptsTopSpacing` | `Double` | `8.0` | Spacing above prompt list (dp) |
 | `--welcome-prompt-padding` | `cssLayout.welcomePromptPadding` | `Double` | `0.0` | Inner padding for prompt pills (dp) |
 | `--welcome-prompt-corner-radius` | `cssLayout.welcomePromptCornerRadius` | `Double` | `8.0` | Prompt pill corner radius (dp) |
+| `--suggestion-item-border-radius` | `cssLayout.suggestionItemBorderRadius` | `Double` | `10.0` | Prompt suggestion chip corner radius (dp) |
 
 ---
 
@@ -914,11 +943,15 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
     "--welcome-prompt-background-color": "#F5F5F5",
     "--welcome-prompt-text-color": "#000000",
     "--welcome-prompt-spacing": "8px",
+    "--suggestion-background-color": "#F0F0F0",
+    "--suggestion-text-color": "#131313",
+    "--suggestion-item-border-radius": "10px",
     "--welcome-title-bottom-spacing": "6px",
     "--welcome-prompts-top-spacing": "12px",
     "--font-family": "",
     "--color-primary": "#EB1000",
     "--color-text": "#131313",
+    "--color-container": "#F0F0F0",
     "--line-height-body": "1.75",
     "--main-container-background": "#FFFFFF",
     "--main-container-bottom-background": "#FFFFFF",
@@ -1157,21 +1190,24 @@ This section documents which properties are fully implemented, partially impleme
 ### Theme Tokens - Colors
 
 **Note**: The following base colors are **not configurable via JSON themes**. They are hardcoded in `LightConciergeColors` / `DarkConciergeColors` and serve as fallback colors throughout the UI:
-- `secondary`, `onSurfaceVariant`, `container`, `outline`, `error`, `onError`
+- `secondary`, `onSurfaceVariant`, `outline`, `error`, `onError`
 
 These colors are used internally by composables but cannot be customized in theme JSON files. See "Fallback Colors" section at the end.
+
+> **Note**: `container` (card/chip background) is now configurable via `--color-container`.
 
 | CSS Variable | Status | Notes | Used In |
 |--------------|--------|-------|---------|
 | `--color-primary` | ✅ | Primary brand color | Product buttons, feedback dialog submit button, feedback checkbox (checked fill), mic button icon, thinking animation |
 | `--color-text` | ✅ | Primary text color; used for body text on main background and for `micButtonColor` in parsed theme (mic icon uses `--color-primary` in UI) | `ChatHeader`, `WelcomeCard`, prompt suggestions (when theme loaded) |
+| `--color-container` | ✅ | Background for cards and container elements; fallback for prompt suggestion chips when `--suggestion-background-color` is not set | `ProductCard`, `PromptSuggestions`, `ChatInputPanel` (fallback) |
 | `--main-container-background` | ✅ | Main chat screen, welcome card, and feedback dialog background | `ChatScreen`, `WelcomeCard`, `FeedbackDialog` |
 | `--main-container-bottom-background` | ✅ | Bottom container/surface background | Input area, voice recording panel |
 | `--message-blocker-background` | ⚠️ | Parsed but not used in UI | - |
 | `--message-user-background` | ✅ | User message bubble background | `ChatMessageItem` |
 | `--message-user-text` | ✅ | User message text color | `ChatMessageItem` |
 | `--message-concierge-background` | ✅ | AI message bubble background | `ChatMessageItem` |
-| `--message-concierge-text` | ✅ | AI message text color, feedback dialog text, feedback button icons, prompt suggestions text, expanded citation list text, chat footer (Sources label and icon) | `ChatMessageItem`, `FeedbackDialog`, `FeedbackButtons`, `PromptSuggestions`, `ExpandedCitations`, `ChatFooter`, `ProductCard` text, `ProductCarousel` switcher color |
+| `--message-concierge-text` | ✅ | AI message text color, feedback dialog text, feedback button icons, prompt suggestion chip text/icon fallback, expanded citation list text, chat footer (Sources label and icon) | `ChatMessageItem`, `FeedbackDialog`, `FeedbackButtons`, `PromptSuggestions`, `ExpandedCitations`, `ChatFooter`, `ProductCard` text, `ProductCarousel` switcher color |
 | `--message-concierge-link-color` | ✅ | Link color in AI messages; expanded citation list URLs | `ExpandedCitations` (citation URLs); message body links when applied |
 | `--button-primary-background` | ✅ | Primary button background | `ProductActionButtons` |
 | `--button-primary-text` | ✅ | Primary button text | `ProductActionButtons` |
@@ -1196,6 +1232,8 @@ These colors are used internally by composables but cannot be customized in them
 | `--input-mic-recording-icon-color` | ✅ | Waveform animation color during recording | `MicButton`, `AnimatedAudioWave` |
 | `--welcome-prompt-background-color` | ✅ | Welcome prompt pill background | `SuggestedPromptItem` |
 | `--welcome-prompt-text-color` | ✅ | Welcome prompt pill text | `SuggestedPromptItem` |
+| `--suggestion-background-color` | ✅ | Prompt suggestion chip background | `PromptSuggestions` |
+| `--suggestion-text-color` | ✅ | Prompt suggestion chip text and icon color | `PromptSuggestions` |
 | `--citations-background-color` | ✅ | Citation pill background | `CircularCitation` |
 | `--citations-text-color` | ✅ | Citation pill (badge) text | `CircularCitation` |
 | `--feedback-icon-btn-background` | ✅ | Thumbs up/down button background | `FeedbackComponents` |
@@ -1283,6 +1321,7 @@ Note: The feedback dialog checkbox uses `--color-primary` for the check box fill
 | `--welcome-prompts-top-spacing` | ✅ | Spacing above prompt list | `WelcomeCard` |
 | `--welcome-prompt-padding` | ✅ | Inner padding for prompt pills | `SuggestedPromptItem` |
 | `--welcome-prompt-corner-radius` | ✅ | Prompt pill corner radius | `SuggestedPromptItem` |
+| `--suggestion-item-border-radius` | ✅ | Prompt suggestion chip corner radius | `PromptSuggestions` |
 
 ### Unsupported CSS Variables
 
@@ -1305,7 +1344,7 @@ The following colors from `LightConciergeColors` / `DarkConciergeColors` are har
 |-------|---------|---------------------|
 | `secondary` | Secondary accent color (currently unused) | - |
 | `onSurfaceVariant` | Muted text and icons for secondary UI elements | `ChatFooter`, `FeedbackDialog` (unchecked checkboxes) |
-| `container` | Background for cards and container elements | `ProductCard`, `PromptSuggestions`, message bubbles (fallback), `ChatInputPanel` (fallback) |
+| `container` | Background for cards and container elements — configurable via `--color-container` | `ProductCard`, `PromptSuggestions` (fallback when `--suggestion-background-color` not set), `ChatInputPanel` (fallback) |
 | `outline` | Borders, separators, and outline elements | `ChatFooter` separator, `ProductActionButtons` (secondary button fallback), `FeedbackDialog` text field border, `ProductCarousel` nav buttons |
 | `error` | Error state background | `ErrorOverlay` background |
 | `onError` | Error state text | `ErrorOverlay` message text |

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/suggestions/PromptSuggestions.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/suggestions/PromptSuggestions.kt
@@ -60,15 +60,25 @@ internal fun PromptSuggestions(
                 top = style.containerTopPadding,
                 start = style.containerStartPadding,
                 end = style.containerEndPadding
-            ),
-        verticalArrangement = Arrangement.spacedBy(style.itemSpacing)
-    ) {
-        suggestions.forEach { suggestion ->
-            PromptSuggestionItem(
-                text = suggestion,
-                onClick = { onSuggestionClick(suggestion) },
-                modifier = Modifier.fillMaxWidth()
             )
+    ) {
+        if (style.showHeader) {
+            Text(
+                text = style.headerText,
+                style = style.headerStyle,
+                color = style.headerColor,
+                modifier = Modifier.padding(bottom = style.headerBottomPadding)
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(style.itemSpacing)) {
+            suggestions.forEach { suggestion ->
+                PromptSuggestionItem(
+                    text = suggestion,
+                    onClick = { onSuggestionClick(suggestion) },
+                    style = style,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }
@@ -80,10 +90,9 @@ internal fun PromptSuggestions(
 private fun PromptSuggestionItem(
     text: String,
     onClick: () -> Unit,
+    style: ConciergeStyles.PromptSuggestionsStyle,
     modifier: Modifier = Modifier
 ) {
-    val style = ConciergeStyles.promptSuggestionsStyle
-
     Card(
         modifier = modifier
             .clickable { onClick() },

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -168,6 +168,38 @@ internal object CSSKeyMapper {
     }
     
     /**
+     * Helper to update welcome prompt colors
+     */
+    private fun updateWelcomePromptColors(
+        cssValue: String,
+        theme: ConciergeThemeTokens,
+        updater: (ConciergeWelcomePromptColors?, String) -> ConciergeWelcomePromptColors
+    ): ConciergeThemeTokens {
+        val color = CSSValueConverter.parseColor(cssValue)
+        return updateColors(theme) { colors ->
+            val promptColors = updater(colors?.welcomePrompt, color.toHexString())
+            colors?.copy(welcomePrompt = promptColors)
+                ?: ConciergeThemeColors(welcomePrompt = promptColors)
+        }
+    }
+
+    /**
+     * Helper to update prompt suggestion colors
+     */
+    private fun updateSuggestionColors(
+        cssValue: String,
+        theme: ConciergeThemeTokens,
+        updater: (ConciergeWelcomePromptColors?, String) -> ConciergeWelcomePromptColors
+    ): ConciergeThemeTokens {
+        val color = CSSValueConverter.parseColor(cssValue)
+        return updateColors(theme) { colors ->
+            val suggestionColors = updater(colors?.promptSuggestion, color.toHexString())
+            colors?.copy(promptSuggestion = suggestionColors)
+                ?: ConciergeThemeColors(promptSuggestion = suggestionColors)
+        }
+    }
+
+    /**
      * Helper to update layout properties
      */
     private fun updateLayout(
@@ -208,7 +240,14 @@ internal object CSSKeyMapper {
                 existing?.copy(text = color) ?: ConciergePrimaryColors(text = color)
             }
         },
-        
+        "color-container" to { cssValue, theme ->
+            val color = CSSValueConverter.parseColor(cssValue)
+            updateColors(theme) { colors ->
+                colors?.copy(container = color.toHexString())
+                    ?: ConciergeThemeColors(container = color.toHexString())
+            }
+        },
+
         // Colors - Surface (using helper)
         "main-container-background" to { cssValue, theme ->
             updateSurfaceColors(cssValue, theme) { existing, color ->
@@ -404,21 +443,25 @@ internal object CSSKeyMapper {
 
         // Colors - Prompt Pill
         "welcome-prompt-background-color" to { cssValue, theme ->
-            val color = CSSValueConverter.parseColor(cssValue)
-            updateColors(theme) { colors ->
-                val promptColors = colors?.welcomePrompt?.copy(backgroundColor = color.toHexString())
-                    ?: ConciergeWelcomePromptColors(backgroundColor = color.toHexString())
-                colors?.copy(welcomePrompt = promptColors)
-                    ?: ConciergeThemeColors(welcomePrompt = promptColors)
+            updateWelcomePromptColors(cssValue, theme) { existing, color ->
+                existing?.copy(backgroundColor = color) ?: ConciergeWelcomePromptColors(backgroundColor = color)
             }
         },
         "welcome-prompt-text-color" to { cssValue, theme ->
-            val color = CSSValueConverter.parseColor(cssValue)
-            updateColors(theme) { colors ->
-                val promptColors = colors?.welcomePrompt?.copy(textColor = color.toHexString())
-                    ?: ConciergeWelcomePromptColors(textColor = color.toHexString())
-                colors?.copy(welcomePrompt = promptColors)
-                    ?: ConciergeThemeColors(welcomePrompt = promptColors)
+            updateWelcomePromptColors(cssValue, theme) { existing, color ->
+                existing?.copy(textColor = color) ?: ConciergeWelcomePromptColors(textColor = color)
+            }
+        },
+
+        // Colors - Prompt Suggestions
+        "suggestion-background-color" to { cssValue, theme ->
+            updateSuggestionColors(cssValue, theme) { existing, color ->
+                existing?.copy(backgroundColor = color) ?: ConciergeWelcomePromptColors(backgroundColor = color)
+            }
+        },
+        "suggestion-text-color" to { cssValue, theme ->
+            updateSuggestionColors(cssValue, theme) { existing, color ->
+                existing?.copy(textColor = color) ?: ConciergeWelcomePromptColors(textColor = color)
             }
         },
 
@@ -655,6 +698,13 @@ internal object CSSKeyMapper {
                 layout?.copy(welcomePromptCornerRadius = radius) ?: ConciergeLayout(welcomePromptCornerRadius = radius)
             }
         },
+        "suggestion-item-border-radius" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val radius = CSSValueConverter.parsePxValue(cssValue) ?: 10.0
+                layout?.copy(suggestionItemBorderRadius = radius) ?: ConciergeLayout(suggestionItemBorderRadius = radius)
+            }
+        },
+
         "header-title-font-size" to { cssValue, theme ->
             updateLayout(theme) { layout ->
                 val size = CSSValueConverter.parsePxValue(cssValue) ?: 24.0

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -84,6 +84,10 @@ data class ConciergeColors(
     val welcomePromptBackground: Color? = null,
     val welcomePromptText: Color? = null,
 
+    // Prompt suggestion colors (from CSS themes)
+    val suggestionBackground: Color? = null,
+    val suggestionText: Color? = null,
+
     // Citation/Disclaimer colors (from CSS themes)
     val citationBackground: Color? = null,
     val citationText: Color? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -602,28 +602,43 @@ internal object ConciergeStyles {
         val iconSpacing: Dp,
         val textStyle: TextStyle,
         val textColor: Color,
-        val textMaxLines: Int
+        val textMaxLines: Int,
+        val showHeader: Boolean,
+        val headerText: String,
+        val headerStyle: TextStyle,
+        val headerColor: Color,
+        val headerBottomPadding: Dp
     )
 
     val promptSuggestionsStyle: PromptSuggestionsStyle
         @Composable get() {
             val themeColors = ConciergeTheme.colors
             val contentColor = themeColors.conciergeMessageText ?: themeColors.onSurface
+            val textColor = themeColors.suggestionText ?: contentColor
+            val behavior = ConciergeTheme.behavior?.promptSuggestions
+            val bubbleStyle = messageBubbleStyle
+            val alignToMessage = behavior?.alignToMessage ?: false
+            val alignedPadding = bubbleStyle.padding + bubbleStyle.innerPadding
             return PromptSuggestionsStyle(
                 containerTopPadding = 6.dp,
-                containerStartPadding = 12.dp,
-                containerEndPadding = 48.dp,
+                containerStartPadding = if (alignToMessage) alignedPadding else 12.dp,
+                containerEndPadding = if (alignToMessage) alignedPadding else 48.dp,
                 itemSpacing = 8.dp,
-                itemShape = RoundedCornerShape(10.dp),
-                itemBackgroundColor = themeColors.container,
+                itemShape = RoundedCornerShape(ConciergeTheme.tokens?.cssLayout?.suggestionItemBorderRadius?.dp ?: 10.dp),
+                itemBackgroundColor = themeColors.suggestionBackground ?: themeColors.container,
                 itemHorizontalPadding = 16.dp,
                 itemVerticalPadding = 12.dp,
                 iconSize = 10.dp,
-                iconColor = contentColor,
+                iconColor = textColor,
                 iconSpacing = 12.dp,
                 textStyle = MaterialTheme.typography.bodyMedium,
-                textColor = contentColor,
-                textMaxLines = 2
+                textColor = textColor,
+                textMaxLines = behavior?.itemMaxLines ?: 1,
+                showHeader = behavior?.showHeader ?: false,
+                headerText = ConciergeTheme.text?.suggestionsHeader ?: "Suggestions",
+                headerStyle = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                headerColor = contentColor,
+                headerBottomPadding = 4.dp
             )
         }
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -104,6 +104,7 @@ data class ConciergeTextStrings(
     val feedbackToastSuccess: String? = null,
     val feedbackHelpfulLabel: String? = null,
     val sourcesLabel: String? = null,
+    val suggestionsHeader: String? = null,
 
     // Error
     val errorNetwork: String? = null
@@ -150,7 +151,8 @@ data class ConciergeThemeColors(
     val feedback: ConciergeFeedbackColors? = null,
     val citation: ConciergeCitationColors? = null,
     val welcomePrompt: ConciergeWelcomePromptColors? = null,
-    val ctaButton: ConciergeCtaButtonColors? = null
+    val ctaButton: ConciergeCtaButtonColors? = null,
+    val promptSuggestion: ConciergeWelcomePromptColors? = null
 )
 
 /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -95,6 +95,7 @@ data class ConciergeLayout(
     val welcomePromptPadding: Double? = null,
     val welcomePromptCornerRadius: Double? = null,
     val headerTitleFontSize: Double? = null,
+    val suggestionItemBorderRadius: Double? = null,
 
     // Extended product cards
     val productCardTitleFontWeight: Int? = null,
@@ -183,7 +184,14 @@ data class ConciergeThemeBehavior(
     val feedback: ConciergeFeedbackBehavior? = null,
     val citations: ConciergeCitationsBehavior? = null,
     val productCard: ConciergeProductCardBehavior? = null,
-    val multimodalCarousel: ConciergeMultimodalCarouselBehavior? = null
+    val multimodalCarousel: ConciergeMultimodalCarouselBehavior? = null,
+    val promptSuggestions: ConciergePromptSuggestionsBehavior? = null
+)
+
+data class ConciergePromptSuggestionsBehavior(
+    val itemMaxLines: Int = 1,
+    val showHeader: Boolean = false,
+    val alignToMessage: Boolean = false
 )
 
 /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -82,6 +82,7 @@ internal object ThemeParser {
                     feedbackToastSuccess = DataReader.optString(it, "feedback.toast.success", null),
                     feedbackHelpfulLabel = DataReader.optString(it, "feedbackHelpfulLabel", null),
                     sourcesLabel = DataReader.optString(it, "sourcesLabel", null),
+                    suggestionsHeader = DataReader.optString(it, "suggestions.header", null),
                     errorNetwork = DataReader.optString(it, "error.network", null)
                 )
             }
@@ -333,6 +334,9 @@ internal object ThemeParser {
             // Prompt pill colors from CSS themes
             welcomePromptBackground = themeColors.welcomePrompt?.backgroundColor?.toComposeColor(),
             welcomePromptText = themeColors.welcomePrompt?.textColor?.toComposeColor(),
+            // Prompt suggestion colors from CSS themes
+            suggestionBackground = themeColors.promptSuggestion?.backgroundColor?.toComposeColor(),
+            suggestionText = themeColors.promptSuggestion?.textColor?.toComposeColor(),
             // Citation/Disclaimer colors from CSS themes
             citationBackground = themeColors.citation?.backgroundColor?.toComposeColor(),
             citationText = themeColors.citation?.textColor?.toComposeColor(),
@@ -429,6 +433,17 @@ internal object ThemeParser {
             )
         }
 
+        val promptSuggestionsMap = typedMap?.get("promptSuggestions") as? Map<*, *>
+        @Suppress("UNCHECKED_CAST")
+        val promptSuggestionsTyped = promptSuggestionsMap as? MutableMap<String?, Any?>
+        val promptSuggestions = promptSuggestionsTyped?.let {
+            ConciergePromptSuggestionsBehavior(
+                itemMaxLines = DataReader.optInt(it, "itemMaxLines", 1),
+                showHeader = DataReader.optBoolean(it, "showHeader", false),
+                alignToMessage = DataReader.optBoolean(it, "alignToMessage", false)
+            )
+        }
+
         return ConciergeThemeBehavior(
             enableDarkMode = DataReader.optBoolean(typedMap, "enableDarkMode", true),
             enableAnimations = DataReader.optBoolean(typedMap, "enableAnimations", true),
@@ -447,7 +462,8 @@ internal object ThemeParser {
             citations = citations,
             productCard = productCard,
             multimodalCarousel = multimodalCarousel,
-            welcomeCard = welcomeCard
+            welcomeCard = welcomeCard,
+            promptSuggestions = promptSuggestions
         )
     }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
@@ -87,6 +87,12 @@ class CSSKeyMapperTest {
         assertEquals("#2C2C2C", result.colors?.primaryColors?.text)
     }
 
+    @Test
+    fun `apply maps color-container`() {
+        val result = CSSKeyMapper.apply("--color-container", "#F0F0F0", emptyTheme)
+        assertEquals("#F0F0F0", result.colors?.container)
+    }
+
     // -----------------------------------------------------------------------
     // Surface colors
     // -----------------------------------------------------------------------
@@ -869,6 +875,12 @@ class CSSKeyMapperTest {
         assertEquals(20.0, result.cssLayout?.welcomePromptCornerRadius)
     }
 
+    @Test
+    fun `apply maps suggestion-item-border-radius`() {
+        val result = CSSKeyMapper.apply("--suggestion-item-border-radius", "24px", emptyTheme)
+        assertEquals(24.0, result.cssLayout?.suggestionItemBorderRadius)
+    }
+
     // -----------------------------------------------------------------------
     // Input Icon Colors
     // -----------------------------------------------------------------------
@@ -899,5 +911,17 @@ class CSSKeyMapperTest {
     fun `apply maps welcome-prompt-text-color`() {
         val result = CSSKeyMapper.apply("--welcome-prompt-text-color", "#000000", emptyTheme)
         assertNotNull(result.colors?.welcomePrompt?.textColor)
+    }
+
+    @Test
+    fun `apply maps suggestion-background-color`() {
+        val result = CSSKeyMapper.apply("--suggestion-background-color", "#E8E8E8", emptyTheme)
+        assertNotNull(result.colors?.promptSuggestion?.backgroundColor)
+    }
+
+    @Test
+    fun `apply maps suggestion-text-color`() {
+        val result = CSSKeyMapper.apply("--suggestion-text-color", "#333333", emptyTheme)
+        assertNotNull(result.colors?.promptSuggestion?.textColor)
     }
 }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
@@ -916,12 +916,12 @@ class CSSKeyMapperTest {
     @Test
     fun `apply maps suggestion-background-color`() {
         val result = CSSKeyMapper.apply("--suggestion-background-color", "#E8E8E8", emptyTheme)
-        assertNotNull(result.colors?.promptSuggestion?.backgroundColor)
+        assertEquals("#E8E8E8", result.colors?.promptSuggestion?.backgroundColor)
     }
 
     @Test
     fun `apply maps suggestion-text-color`() {
         val result = CSSKeyMapper.apply("--suggestion-text-color", "#333333", emptyTheme)
-        assertNotNull(result.colors?.promptSuggestion?.textColor)
+        assertEquals("#333333", result.colors?.promptSuggestion?.textColor)
     }
 }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
@@ -1725,7 +1725,7 @@ class ThemeParserTest {
     // -----------------------------------------------------------------------
 
     @Test
-    fun `parseThemeJson should parse suggestion chip colors`() {
+    fun `parseThemeTokens should parse suggestion chip colors`() {
         val json = """
             {
                 "theme": {

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
@@ -1600,5 +1600,179 @@ class ThemeParserTest {
         assertNotNull(colors.welcomePromptBackground)
         assertNotNull(colors.welcomePromptText)
     }
+
+    // -----------------------------------------------------------------------
+    // Prompt suggestions behavior
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parseThemeTokens should parse behavior promptSuggestions itemMaxLines`() {
+        val json = """
+            {
+                "behavior": {
+                    "promptSuggestions": {
+                        "itemMaxLines": 3
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertEquals(3, tokens?.behavior?.promptSuggestions?.itemMaxLines)
+    }
+
+    @Test
+    fun `parseThemeTokens should parse behavior promptSuggestions showHeader`() {
+        val json = """
+            {
+                "behavior": {
+                    "promptSuggestions": {
+                        "showHeader": true
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertEquals(true, tokens?.behavior?.promptSuggestions?.showHeader)
+    }
+
+    @Test
+    fun `parseThemeTokens should parse behavior promptSuggestions alignToMessage`() {
+        val json = """
+            {
+                "behavior": {
+                    "promptSuggestions": {
+                        "alignToMessage": true
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertEquals(true, tokens?.behavior?.promptSuggestions?.alignToMessage)
+    }
+
+    @Test
+    fun `parseThemeTokens should use default promptSuggestions values when block is empty`() {
+        val json = """
+            {
+                "behavior": {
+                    "promptSuggestions": {}
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertEquals(1, tokens?.behavior?.promptSuggestions?.itemMaxLines)
+        assertEquals(false, tokens?.behavior?.promptSuggestions?.showHeader)
+        assertEquals(false, tokens?.behavior?.promptSuggestions?.alignToMessage)
+    }
+
+    @Test
+    fun `parseThemeTokens should return null promptSuggestions when not provided`() {
+        val json = """
+            {
+                "behavior": {
+                    "input": {
+                        "enableVoiceInput": true
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertNull(tokens?.behavior?.promptSuggestions)
+    }
+
+    @Test
+    fun `parseThemeJson should parse suggestions header text`() {
+        val json = """
+            {
+                "text": {
+                    "suggestions.header": "Try asking"
+                }
+            }
+        """.trimIndent()
+
+        val config = ThemeParser.parseThemeJson(json)
+        assertNotNull(config)
+        assertEquals("Try asking", config?.text?.suggestionsHeader)
+    }
+
+    @Test
+    fun `parseThemeJson should return null suggestionsHeader when not provided`() {
+        val json = """
+            {
+                "text": {
+                    "input.placeholder": "Ask me anything"
+                }
+            }
+        """.trimIndent()
+
+        val config = ThemeParser.parseThemeJson(json)
+        assertNotNull(config)
+        assertNull(config?.text?.suggestionsHeader)
+    }
+
+    // -----------------------------------------------------------------------
+    // Prompt suggestion chip colors
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parseThemeJson should parse suggestion chip colors`() {
+        val json = """
+            {
+                "theme": {
+                    "--suggestion-background-color": "#E8F0FE",
+                    "--suggestion-text-color": "#1A1A1A"
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        assertNotNull(tokens)
+        assertNotNull(tokens?.colors?.promptSuggestion?.backgroundColor)
+        assertNotNull(tokens?.colors?.promptSuggestion?.textColor)
+    }
+
+    @Test
+    fun `createColorsFromJson should map suggestion chip background color`() {
+        val themeColors = ConciergeThemeColors(
+            promptSuggestion = ConciergeWelcomePromptColors(
+                backgroundColor = "#E8F0FE",
+                textColor = null
+            )
+        )
+
+        val colors = ThemeParser.createColorsFromJson(themeColors, LightConciergeColors)
+        assertEquals(Color(0xFFE8F0FE), colors.suggestionBackground)
+    }
+
+    @Test
+    fun `createColorsFromJson should map suggestion chip text color`() {
+        val themeColors = ConciergeThemeColors(
+            promptSuggestion = ConciergeWelcomePromptColors(
+                backgroundColor = null,
+                textColor = "#1A1A1A"
+            )
+        )
+
+        val colors = ThemeParser.createColorsFromJson(themeColors, LightConciergeColors)
+        assertEquals(Color(0xFF1A1A1A), colors.suggestionText)
+    }
+
+    @Test
+    fun `createColorsFromJson should return null suggestion colors when not provided`() {
+        val themeColors = ConciergeThemeColors(primary = "#FF0000")
+        val colors = ThemeParser.createColorsFromJson(themeColors, LightConciergeColors)
+        assertNull(colors.suggestionBackground)
+        assertNull(colors.suggestionText)
+    }
 }
 

--- a/code/testapp/src/main/assets/themeDemo.json
+++ b/code/testapp/src/main/assets/themeDemo.json
@@ -42,6 +42,11 @@
       "promptFullWidth": false,
       "promptMaxLines": 2,
       "contentAlignment": "top"
+    },
+    "promptSuggestions": {
+      "itemMaxLines": 1,
+      "showHeader": true,
+      "alignToMessage": true
     }
   },
   "disclaimer": {
@@ -81,7 +86,8 @@
     "feedback.dialog.notes.placeholder": "[DEMO] Share your thoughts here...",
     "feedback.toast.success": "[DEMO] Feedback received! Thank you.",
     "feedback.thumbsUp.aria": "Thumbs up",
-    "feedback.thumbsDown.aria": "Thumbs down"
+    "feedback.thumbsDown.aria": "Thumbs down",
+    "suggestions.header": "Try asking"
   },
   "arrays": {
     "welcome.examples": [
@@ -168,6 +174,7 @@
     "--color-button-secondary-hover-text": "#5C4A24",
     "--color-button-submit": "#7A5C1E",
     "--color-button-submit-hover": "#5F4715",
+    "--color-container": "#EDE4D6",
     "--color-primary": "#7A5C1E",
     "--color-text": "#2C2419",
     "--cta-button-background-color": "#EDE4D6",
@@ -248,6 +255,9 @@
     "--product-card-was-price-font-weight": "400",
     "--product-card-was-price-text-prefix": "was ",
     "--product-card-width": "222",
+    "--suggestion-background-color": "#EDE4D6",
+    "--suggestion-item-border-radius": "20px",
+    "--suggestion-text-color": "#2C2419",
     "--submit-button-fill-color": "#FFFDF9",
     "--submit-button-fill-color-disabled": "#D4C9B8",
     "--welcome-cards-order": "2",


### PR DESCRIPTION
## Description

Adds full theming and behavior configuration support for the prompt suggestion chips displayed after concierge responses. Previously, suggestion chips had no customization options and relied entirely on the theme's default container color. This PR wires up new CSS keys, behavior flags, and text strings that allow integrators to control the appearance and layout of suggestion chips via the theme JSON.

### Changes

**New CSS keys (`theme` block)**
- `--color-container` — wires the previously unmapped container color used as the default chip background
- `--suggestion-background-color` — explicit background color for suggestion chips
- `--suggestion-text-color` — text and icon color for suggestion chips
- `--suggestion-item-border-radius` — corner radius for suggestion chip shape

**New behavior config (`behavior.promptSuggestions`)**
- `itemMaxLines` — max lines of text per chip (default: `1`)
- `showHeader` — displays a "Suggestions" section header above the chips (default: `false`)
- `alignToMessage` — aligns chips to the inner content edge of the bot message bubble instead of the default offset (default: `false`)

**New text string**
- `text["suggestions.header"]` — customizes the header label (default: `"Suggestions"`)

**Code refactoring**
- `PromptSuggestionItem` now receives the already-computed `style` from its parent instead of re-invoking the `@Composable` getter a second time
- Removed `ConciergePromptSuggestionColors` (was structurally identical to `ConciergeWelcomePromptColors`); `promptSuggestion` field now reuses `ConciergeWelcomePromptColors`
- Extracted `updateWelcomePromptColors` and `updateSuggestionColors` helper functions in `CSSKeyMapper` matching the existing helper pattern

**Documentation**
The style guide has been updated with the new json configuration options.

## Related Issue

## Motivation and Context
Integrators need control over suggestion chip appearance to match their brand. Without configurable colors, border radius, and alignment, chips were visually inconsistent with custom themes. The `alignToMessage` flag specifically addresses the common design requirement of aligning suggestions to the text edge of the bot bubble.

## How Has This Been Tested?
- Manual testing with `themeDemo.json` configured with all new keys and behavior flags
- `themeDemo.json` updated to exercise: `--suggestion-background-color`, `--suggestion-text-color`, `--suggestion-item-border-radius`, `--color-container`, `promptSuggestions` behavior block, and `suggestions.header` text string
- New unit tests added to `CSSKeyMapperTest` covering `--color-container`, `--suggestion-background-color`, `--suggestion-text-color`, `--suggestion-item-border-radius`
- New unit tests added to `ThemeParserTest` covering `behavior.promptSuggestions` (`itemMaxLines`, `showHeader`, `alignToMessage`, defaults, absent block), `text["suggestions.header"]`, and `createColorsFromJson` mapping for `suggestionBackground` and `suggestionText`

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
