### PR TITLE
Handle non-http schemes with system intents

### DIFF
--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ConciergeConstants.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ConciergeConstants.kt
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.concierge
 internal object ConciergeConstants {
     const val EXTENSION_NAME = "brandconcierge"
     const val EXTENSION_FRIENDLY_NAME = "BrandConcierge"
-    const val VERSION = "3.3.0"
+    const val VERSION = "3.3.1"
     const val LOG_TAG = "BrandConcierge"
     const val DATA_STORE_NAME = EXTENSION_NAME
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -44,11 +44,12 @@ import com.adobe.marketing.mobile.concierge.ui.state.MicEvent
 import com.adobe.marketing.mobile.concierge.ui.state.UserInputState
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeThemeConfig
 import com.adobe.marketing.mobile.concierge.ui.theme.toWelcomeConfig
-import com.adobe.marketing.mobile.concierge.ui.webview.WebViewSheetContentSchemes
 import com.adobe.marketing.mobile.concierge.utils.WelcomeResponseParser
 import com.adobe.marketing.mobile.concierge.utils.citation.CitationUtils
 import com.adobe.marketing.mobile.concierge.utils.image.DefaultImageProvider
 import com.adobe.marketing.mobile.concierge.utils.image.ImageProvider
+import com.adobe.marketing.mobile.concierge.utils.isAllowedUrlScheme
+import com.adobe.marketing.mobile.concierge.utils.isBlockedUrlScheme
 import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
 import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import com.adobe.marketing.mobile.services.Log
@@ -214,8 +215,11 @@ class ConciergeChatViewModel : AndroidViewModel {
             tryOpenAsAppLink(getApplication(), url) -> {
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: opened as App Link")
             }
-            !WebViewSheetContentSchemes.isAllowedScheme(url) && !WebViewSheetContentSchemes.isBlockedScheme(url) -> {
-                // Non-http/https, non-blocked scheme (e.g. tel:, geo:, mailto:) — forward to system.
+            isBlockedUrlScheme(url) -> {
+                Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: blocked scheme, ignoring")
+            }
+            !isAllowedUrlScheme(url) -> {
+                // Non-http/https scheme (e.g. tel:, geo:, mailto:) — forward to system.
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: forwarding system scheme to device")
                 tryOpenWithSystemHandler(getApplication(), url)
             }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -14,7 +14,9 @@ package com.adobe.marketing.mobile.concierge.ui.chat
 
 import android.Manifest
 import android.app.Application
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -48,6 +50,7 @@ import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCapturing
 import com.adobe.marketing.mobile.concierge.utils.WelcomeResponseParser
 import com.adobe.marketing.mobile.concierge.utils.image.DefaultImageProvider
 import com.adobe.marketing.mobile.concierge.utils.image.ImageProvider
+import com.adobe.marketing.mobile.concierge.ui.webview.WebViewSheetContentSchemes
 import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
@@ -211,6 +214,17 @@ class ConciergeChatViewModel : AndroidViewModel {
             }
             tryOpenAsAppLink(getApplication(), url) -> {
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: opened as App Link")
+            }
+            !WebViewSheetContentSchemes.isAllowedScheme(url) && !WebViewSheetContentSchemes.isBlockedScheme(url) -> {
+                // Non-http/https, non-blocked scheme (e.g. tel:, geo:, mailto:) — forward to system.
+                Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: forwarding system scheme to device")
+                try {
+                    getApplication<Application>().startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        }
+                    )
+                } catch (_: Exception) { }
             }
             else -> {
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: opening in WebView overlay")

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModel.kt
@@ -14,9 +14,7 @@ package com.adobe.marketing.mobile.concierge.ui.chat
 
 import android.Manifest
 import android.app.Application
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -30,8 +28,10 @@ import com.adobe.marketing.mobile.concierge.network.ParsedMultimodalItem
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
 import com.adobe.marketing.mobile.concierge.ui.components.footer.FeedbackState
 import com.adobe.marketing.mobile.concierge.ui.config.WelcomeConfig
-import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeThemeConfig
-import com.adobe.marketing.mobile.concierge.ui.theme.toWelcomeConfig
+import com.adobe.marketing.mobile.concierge.ui.stt.AndroidSpeechCapturing
+import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureError
+import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureListener
+import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCapturing
 import com.adobe.marketing.mobile.concierge.ui.state.ChatEvent
 import com.adobe.marketing.mobile.concierge.ui.state.ChatMessage
 import com.adobe.marketing.mobile.concierge.ui.state.ChatScreenState
@@ -41,17 +41,16 @@ import com.adobe.marketing.mobile.concierge.ui.state.FeedbackType
 import com.adobe.marketing.mobile.concierge.ui.state.MessageContent
 import com.adobe.marketing.mobile.concierge.ui.state.MessageInteractionEvent
 import com.adobe.marketing.mobile.concierge.ui.state.MicEvent
-import com.adobe.marketing.mobile.concierge.utils.citation.CitationUtils
 import com.adobe.marketing.mobile.concierge.ui.state.UserInputState
-import com.adobe.marketing.mobile.concierge.ui.stt.AndroidSpeechCapturing
-import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureError
-import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureListener
-import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCapturing
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeThemeConfig
+import com.adobe.marketing.mobile.concierge.ui.theme.toWelcomeConfig
+import com.adobe.marketing.mobile.concierge.ui.webview.WebViewSheetContentSchemes
 import com.adobe.marketing.mobile.concierge.utils.WelcomeResponseParser
+import com.adobe.marketing.mobile.concierge.utils.citation.CitationUtils
 import com.adobe.marketing.mobile.concierge.utils.image.DefaultImageProvider
 import com.adobe.marketing.mobile.concierge.utils.image.ImageProvider
-import com.adobe.marketing.mobile.concierge.ui.webview.WebViewSheetContentSchemes
 import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
+import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -218,13 +217,7 @@ class ConciergeChatViewModel : AndroidViewModel {
             !WebViewSheetContentSchemes.isAllowedScheme(url) && !WebViewSheetContentSchemes.isBlockedScheme(url) -> {
                 // Non-http/https, non-blocked scheme (e.g. tel:, geo:, mailto:) — forward to system.
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: forwarding system scheme to device")
-                try {
-                    getApplication<Application>().startActivity(
-                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                    )
-                } catch (_: Exception) { }
+                tryOpenWithSystemHandler(getApplication(), url)
             }
             else -> {
                 Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "handleLinkClick: opening in WebView overlay")

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
@@ -16,7 +16,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color as AndroidColor
-import android.net.Uri
 import android.os.Build
 import android.view.MotionEvent
 import android.view.ViewGroup
@@ -30,34 +29,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import com.adobe.marketing.mobile.concierge.utils.isAllowedUrlScheme
+import com.adobe.marketing.mobile.concierge.utils.isBlockedUrlScheme
 import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
 import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import java.nio.charset.StandardCharsets
-
-/**
- * URL scheme validation for the WebView sheet content.
- * Only http and https are allowed to load inside the WebView; if the host app is a verified
- * App Link handler for the domain, the URL is forwarded to the app instead.
- * All other schemes are forwarded to the system unless explicitly blocked.
- * Blocked schemes: javascript, file, content, intent, data.
- * Internal for unit testing.
- */
-internal object WebViewSheetContentSchemes {
-    private val allowedSchemes = setOf("https", "http")
-    internal val blockedSchemes = setOf("javascript", "file", "content", "intent", "data")
-
-    private fun scheme(url: String) = Uri.parse(url).scheme?.lowercase() ?: ""
-
-    fun isAllowedScheme(url: String?): Boolean {
-        if (url.isNullOrBlank()) return false
-        return scheme(url) in allowedSchemes
-    }
-
-    fun isBlockedScheme(url: String?): Boolean {
-        if (url.isNullOrBlank()) return false
-        return scheme(url) in blockedSchemes
-    }
-}
 
 /**
  * WebView sheet content shown inside [WebviewOverlayDialog].
@@ -99,7 +75,7 @@ internal fun WebViewSheetContent(
             },
             update = { webView ->
                 webView.setBackgroundColor(AndroidColor.TRANSPARENT)
-                if (webView.url != url && WebViewSheetContentSchemes.isAllowedScheme(url)) {
+                if (webView.url != url && isAllowedUrlScheme(url)) {
                     webView.loadUrl(url)
                 }
             },
@@ -160,8 +136,8 @@ internal class SecureSheetWebViewClient(private val context: Context) : WebViewC
 
     private fun handleUrl(url: String?): Boolean {
         if (url == null) return true
-        if (WebViewSheetContentSchemes.isBlockedScheme(url)) return true
-        if (WebViewSheetContentSchemes.isAllowedScheme(url)) {
+        if (isBlockedUrlScheme(url)) return true
+        if (isAllowedUrlScheme(url)) {
             // http/https: forward to host app if it is a verified App Link handler,
             // otherwise let the WebView load the page.
             return tryOpenAsAppLink(context, url)

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.concierge.ui.webview
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color as AndroidColor
 import android.net.Uri
@@ -32,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
+import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import java.nio.charset.StandardCharsets
 
 /**
@@ -139,7 +139,7 @@ private fun applySecureSettings(settings: WebSettings) {
  * Non-web schemes are forwarded to the system unless explicitly blocked.
  * Dangerous schemes (javascript, file, content, intent, data) are blocked.
  */
-private class SecureSheetWebViewClient(private val context: Context) : WebViewClient() {
+internal class SecureSheetWebViewClient(private val context: Context) : WebViewClient() {
     override fun shouldOverrideUrlLoading(
         view: WebView,
         request: WebResourceRequest
@@ -167,11 +167,7 @@ private class SecureSheetWebViewClient(private val context: Context) : WebViewCl
             return tryOpenAsAppLink(context, url)
         }
         // All other schemes (e.g. mailto:, tel:, myapp://): forward to the system.
-        try {
-            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            })
-        } catch (_: Exception) { }
+        tryOpenWithSystemHandler(context, url)
         return true
     }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContent.kt
@@ -168,7 +168,9 @@ private class SecureSheetWebViewClient(private val context: Context) : WebViewCl
         }
         // All other schemes (e.g. mailto:, tel:, myapp://): forward to the system.
         try {
-            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
         } catch (_: Exception) { }
         return true
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtils.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtils.kt
@@ -23,6 +23,26 @@ import androidx.core.net.toUri
 import com.adobe.marketing.mobile.concierge.ConciergeConstants
 import com.adobe.marketing.mobile.services.Log
 
+private val ALLOWED_URL_SCHEMES = setOf("https", "http")
+private val BLOCKED_URL_SCHEMES = setOf("javascript", "file", "content", "intent", "data")
+
+/**
+ * Returns true if the URL has an http or https scheme.
+ */
+internal fun isAllowedUrlScheme(url: String?): Boolean {
+    if (url.isNullOrBlank()) return false
+    return Uri.parse(url).scheme?.lowercase() in ALLOWED_URL_SCHEMES
+}
+
+/**
+ * Returns true if the URL has a scheme that must never be opened or loaded
+ * (javascript, file, content, intent, data).
+ */
+internal fun isBlockedUrlScheme(url: String?): Boolean {
+    if (url.isNullOrBlank()) return false
+    return Uri.parse(url).scheme?.lowercase() in BLOCKED_URL_SCHEMES
+}
+
 /**
  * Opens a URL using the system handler via [Intent.ACTION_VIEW].
  * Intended for non-http/https schemes such as tel:, mailto:, geo:, sms:, and custom deep links.

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtils.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtils.kt
@@ -24,6 +24,21 @@ import com.adobe.marketing.mobile.concierge.ConciergeConstants
 import com.adobe.marketing.mobile.services.Log
 
 /**
+ * Opens a URL using the system handler via [Intent.ACTION_VIEW].
+ * Intended for non-http/https schemes such as tel:, mailto:, geo:, sms:, and custom deep links.
+ * Requires [Intent.FLAG_ACTIVITY_NEW_TASK] since the caller may not be an Activity context.
+ */
+internal fun tryOpenWithSystemHandler(context: Context, url: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        })
+    } catch (e: Exception) {
+        Log.debug(ConciergeConstants.EXTENSION_NAME, "AppLinkUtils", "tryOpenWithSystemHandler failed: ${e.message}")
+    }
+}
+
+/**
  * Attempts to open a URL as an App Link if the host app is the verified handler
  * (e.g., listed in the domain's assetlinks.json). Returns true if the link was opened;
  * false if the host app does not handle it (caller should fall back to WebView).

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ConciergeExtensionTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ConciergeExtensionTest.kt
@@ -127,7 +127,7 @@ class ConciergeExtensionTest {
         // Verify the constants used by the extension
         assertEquals("brandconcierge", ConciergeConstants.EXTENSION_NAME)
         assertEquals("BrandConcierge", ConciergeConstants.EXTENSION_FRIENDLY_NAME)
-        assertEquals("3.3.0", ConciergeConstants.VERSION)
+        assertEquals("3.3.1", ConciergeConstants.VERSION)
     }
 
     // ========== hasValidXdmSharedState Tests ==========

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.concierge.ui.chat
 
 import android.app.Application
 import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.core.content.ContextCompat
 import com.adobe.marketing.mobile.concierge.network.Citation
 import com.adobe.marketing.mobile.concierge.network.ConciergeConversationServiceClient
@@ -36,11 +37,15 @@ import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureError
 import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCaptureListener
 import com.adobe.marketing.mobile.concierge.ui.stt.SpeechCapturing
 import com.adobe.marketing.mobile.services.ServiceProvider
+import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
+import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
@@ -1249,15 +1254,157 @@ class ConciergeChatViewModelTest {
     fun `updateWelcomeConfigFromTheme with null does not change config`() = runTest {
         val fakeSpeech = FakeSpeechCapturing()
         val chatClient = mockk<ConciergeConversationServiceClient>(relaxed = true)
-        
+
         val vm = ConciergeChatViewModel(app, fakeSpeech, chatClient)
-        
+
         val originalConfig = vm.welcomeConfig.value
-        
+
         vm.updateWelcomeConfigFromTheme(null)
-        
+
         // Config should remain unchanged
         assertEquals(originalConfig, vm.welcomeConfig.value)
+    }
+
+    // ========== handleLinkClick Tests ==========
+
+    private fun setupSchemeMocks() {
+        mockkStatic(Uri::class)
+        mockkStatic(::tryOpenAsAppLink)
+        mockkStatic(::tryOpenWithSystemHandler)
+        every { Uri.parse(any()) } answers {
+            val url = firstArg<String>()
+            val scheme = url.substringBefore(':', "").lowercase().ifEmpty { null }
+            mockk { every { this@mockk.scheme } returns scheme }
+        }
+        every { tryOpenAsAppLink(any(), any()) } returns false
+        every { tryOpenWithSystemHandler(any(), any()) } just Runs
+    }
+
+    private fun teardownSchemeMocks() {
+        unmockkStatic(Uri::class)
+        unmockkStatic(::tryOpenAsAppLink)
+        unmockkStatic(::tryOpenWithSystemHandler)
+    }
+
+    @Test
+    fun `handleLinkClick with blank URL does nothing`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("   ", null)
+
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick host callback returning true prevents any further handling`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("tel:+15555550100", handleLink = { true })
+
+        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with tel scheme calls tryOpenWithSystemHandler and does not open overlay`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("tel:+15555550100", null)
+
+        verify { tryOpenWithSystemHandler(app, "tel:+15555550100") }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with geo scheme calls tryOpenWithSystemHandler`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("geo:0,0?q=1+Apple+Park+Way", null)
+
+        verify { tryOpenWithSystemHandler(app, "geo:0,0?q=1+Apple+Park+Way") }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with mailto scheme calls tryOpenWithSystemHandler`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("mailto:user@example.com", null)
+
+        verify { tryOpenWithSystemHandler(app, "mailto:user@example.com") }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with https URL opens overlay when not an App Link`() = runTest {
+        setupSchemeMocks()
+        every { tryOpenAsAppLink(any(), any()) } returns false
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("https://example.com", null)
+
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        assertEquals("https://example.com", vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with https URL handled as App Link does not open overlay`() = runTest {
+        setupSchemeMocks()
+        every { tryOpenAsAppLink(any(), any()) } returns true
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("https://example.com", null)
+
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick with blocked scheme opens overlay without calling system handler`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("javascript:alert(1)", null)
+
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        assertEquals("javascript:alert(1)", vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
+    }
+
+    @Test
+    fun `handleLinkClick host callback returning false falls through to normal routing`() = runTest {
+        setupSchemeMocks()
+
+        val vm = ConciergeChatViewModel(app)
+        vm.handleLinkClick("tel:+15555550100", handleLink = { false })
+
+        verify { tryOpenWithSystemHandler(app, "tel:+15555550100") }
+        assertNull(vm.webviewOverlay.value)
+
+        teardownSchemeMocks()
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/chat/ConciergeChatViewModelTest.kt
@@ -42,10 +42,10 @@ import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.Runs
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
@@ -81,19 +81,34 @@ class ConciergeChatViewModelTest {
         // Default: grant audio permission
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns PackageManager.PERMISSION_GRANTED
-        
+
         // Mock ServiceProvider and UriService
         mockkStatic(ServiceProvider::class)
         mockServiceProvider = mockk<ServiceProvider>(relaxed = true)
         every { ServiceProvider.getInstance() } returns mockServiceProvider
         every { mockServiceProvider.uriService } returns mockk(relaxed = true)
         every { mockServiceProvider.uriService.openUri(any()) } returns true
+
+        // Scheme mocks for handleLinkClick tests
+        mockkStatic(Uri::class)
+        mockkStatic(::tryOpenAsAppLink)
+        mockkStatic(::tryOpenWithSystemHandler)
+        every { Uri.parse(any()) } answers {
+            val url = firstArg<String>()
+            val scheme = url.substringBefore(':', "").lowercase().ifEmpty { null }
+            mockk { every { this@mockk.scheme } returns scheme }
+        }
+        every { tryOpenAsAppLink(any(), any()) } returns false
+        every { tryOpenWithSystemHandler(any(), any()) } just Runs
     }
 
     @After
     fun tearDown() {
         unmockkStatic(ContextCompat::class)
         unmockkStatic(ServiceProvider::class)
+        unmockkStatic(Uri::class)
+        unmockkStatic(::tryOpenAsAppLink)
+        unmockkStatic(::tryOpenWithSystemHandler)
         Dispatchers.resetMain()
     }
 
@@ -1267,109 +1282,64 @@ class ConciergeChatViewModelTest {
 
     // ========== handleLinkClick Tests ==========
 
-    private fun setupSchemeMocks() {
-        mockkStatic(Uri::class)
-        mockkStatic(::tryOpenAsAppLink)
-        mockkStatic(::tryOpenWithSystemHandler)
-        every { Uri.parse(any()) } answers {
-            val url = firstArg<String>()
-            val scheme = url.substringBefore(':', "").lowercase().ifEmpty { null }
-            mockk { every { this@mockk.scheme } returns scheme }
-        }
-        every { tryOpenAsAppLink(any(), any()) } returns false
-        every { tryOpenWithSystemHandler(any(), any()) } just Runs
-    }
-
-    private fun teardownSchemeMocks() {
-        unmockkStatic(Uri::class)
-        unmockkStatic(::tryOpenAsAppLink)
-        unmockkStatic(::tryOpenWithSystemHandler)
-    }
-
     @Test
     fun `handleLinkClick with blank URL does nothing`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("   ", null)
 
         verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
         verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick host callback returning true prevents any further handling`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("tel:+15555550100", handleLink = { true })
 
         verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
         verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick with tel scheme calls tryOpenWithSystemHandler and does not open overlay`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("tel:+15555550100", null)
 
         verify { tryOpenWithSystemHandler(app, "tel:+15555550100") }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick with geo scheme calls tryOpenWithSystemHandler`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("geo:0,0?q=1+Apple+Park+Way", null)
 
         verify { tryOpenWithSystemHandler(app, "geo:0,0?q=1+Apple+Park+Way") }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick with mailto scheme calls tryOpenWithSystemHandler`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("mailto:user@example.com", null)
 
         verify { tryOpenWithSystemHandler(app, "mailto:user@example.com") }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick with https URL opens overlay when not an App Link`() = runTest {
-        setupSchemeMocks()
-        every { tryOpenAsAppLink(any(), any()) } returns false
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("https://example.com", null)
 
         verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
         assertEquals("https://example.com", vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
     fun `handleLinkClick with https URL handled as App Link does not open overlay`() = runTest {
-        setupSchemeMocks()
         every { tryOpenAsAppLink(any(), any()) } returns true
 
         val vm = ConciergeChatViewModel(app)
@@ -1377,34 +1347,24 @@ class ConciergeChatViewModelTest {
 
         verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 
     @Test
-    fun `handleLinkClick with blocked scheme opens overlay without calling system handler`() = runTest {
-        setupSchemeMocks()
-
+    fun `handleLinkClick with blocked scheme is silently dropped`() = runTest {
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("javascript:alert(1)", null)
 
         verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
-        assertEquals("javascript:alert(1)", vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
+        assertNull(vm.webviewOverlay.value)
     }
 
     @Test
     fun `handleLinkClick host callback returning false falls through to normal routing`() = runTest {
-        setupSchemeMocks()
-
         val vm = ConciergeChatViewModel(app)
         vm.handleLinkClick("tel:+15555550100", handleLink = { false })
 
         verify { tryOpenWithSystemHandler(app, "tel:+15555550100") }
         assertNull(vm.webviewOverlay.value)
-
-        teardownSchemeMocks()
     }
 }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.webview
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import com.adobe.marketing.mobile.concierge.utils.tryOpenAsAppLink
+import com.adobe.marketing.mobile.concierge.utils.tryOpenWithSystemHandler
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.Runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class WebViewSheetContentClientTest {
+
+    private lateinit var context: Context
+    private lateinit var view: WebView
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        view = mockk(relaxed = true)
+
+        mockkStatic(Uri::class)
+        mockkStatic(::tryOpenAsAppLink)
+        mockkStatic(::tryOpenWithSystemHandler)
+
+        every { Uri.parse(any()) } answers {
+            val url = firstArg<String>()
+            val scheme = url.substringBefore(':', "").lowercase().ifEmpty { null }
+            mockk { every { this@mockk.scheme } returns scheme }
+        }
+        every { tryOpenAsAppLink(any(), any()) } returns false
+        every { tryOpenWithSystemHandler(any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Uri::class)
+        unmockkStatic(::tryOpenAsAppLink)
+        unmockkStatic(::tryOpenWithSystemHandler)
+    }
+
+    // ---- shouldOverrideUrlLoading (String overload) ----
+
+    @Test
+    fun `null URL returns true and takes no action`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, null as String?)
+
+        assertTrue(result)
+        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `blocked javascript scheme returns true and takes no action`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "javascript:alert(1)")
+
+        assertTrue(result)
+        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `blocked file scheme returns true and takes no action`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "file:///data/local/tmp/file.html")
+
+        assertTrue(result)
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `http URL that is an App Link returns true`() {
+        every { tryOpenAsAppLink(any(), any()) } returns true
+
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "http://example.com/page")
+
+        assertTrue(result)
+        verify { tryOpenAsAppLink(context, "http://example.com/page") }
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `http URL that is not an App Link returns false to load in WebView`() {
+        every { tryOpenAsAppLink(any(), any()) } returns false
+
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "http://example.com/page")
+
+        assertFalse(result)
+        verify { tryOpenAsAppLink(context, "http://example.com/page") }
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `https URL that is not an App Link returns false to load in WebView`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "https://example.com/page")
+
+        assertFalse(result)
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    @Test
+    fun `tel scheme calls tryOpenWithSystemHandler and returns true`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "tel:+15555550100")
+
+        assertTrue(result)
+        verify { tryOpenWithSystemHandler(context, "tel:+15555550100") }
+        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
+    }
+
+    @Test
+    fun `geo scheme calls tryOpenWithSystemHandler and returns true`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "geo:0,0?q=1+Apple+Park+Way")
+
+        assertTrue(result)
+        verify { tryOpenWithSystemHandler(context, "geo:0,0?q=1+Apple+Park+Way") }
+    }
+
+    @Test
+    fun `mailto scheme calls tryOpenWithSystemHandler and returns true`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "mailto:user@example.com")
+
+        assertTrue(result)
+        verify { tryOpenWithSystemHandler(context, "mailto:user@example.com") }
+    }
+
+    @Test
+    fun `custom app scheme calls tryOpenWithSystemHandler and returns true`() {
+        val client = SecureSheetWebViewClient(context)
+        @Suppress("DEPRECATION")
+        val result = client.shouldOverrideUrlLoading(view, "myapp://screen/detail")
+
+        assertTrue(result)
+        verify { tryOpenWithSystemHandler(context, "myapp://screen/detail") }
+    }
+
+    // ---- shouldOverrideUrlLoading (WebResourceRequest overload) ----
+
+    @Test
+    fun `WebResourceRequest with tel URL calls tryOpenWithSystemHandler`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.url } returns Uri.parse("tel:+15555550100")
+        // Override so parse returns a proper Uri mock for the request URL
+        every { Uri.parse("tel:+15555550100") } returns mockk {
+            every { scheme } returns "tel"
+            every { toString() } returns "tel:+15555550100"
+        }
+
+        val client = SecureSheetWebViewClient(context)
+        val result = client.shouldOverrideUrlLoading(view, request)
+
+        assertTrue(result)
+        verify { tryOpenWithSystemHandler(context, "tel:+15555550100") }
+    }
+
+    @Test
+    fun `WebResourceRequest with null URL returns true`() {
+        val request = mockk<WebResourceRequest>()
+        every { request.url } returns null
+
+        val client = SecureSheetWebViewClient(context)
+        val result = client.shouldOverrideUrlLoading(view, request)
+
+        assertTrue(result)
+        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+    }
+
+    // ---- onPageStarted ----
+
+    @Test
+    fun `onPageStarted with data URL stops loading`() {
+        every { view.canGoBack() } returns false
+
+        val client = SecureSheetWebViewClient(context)
+        client.onPageStarted(view, "data:text/html,<script>alert(1)</script>", null)
+
+        verify { view.stopLoading() }
+        verify { view.loadUrl("about:blank") }
+    }
+
+    @Test
+    fun `onPageStarted with data URL navigates back when history exists`() {
+        every { view.canGoBack() } returns true
+
+        val client = SecureSheetWebViewClient(context)
+        client.onPageStarted(view, "data:text/html,test", null)
+
+        verify { view.stopLoading() }
+        verify { view.goBack() }
+        verify(exactly = 0) { view.loadUrl(any()) }
+    }
+
+    @Test
+    fun `onPageStarted with data URL is case-insensitive`() {
+        every { view.canGoBack() } returns false
+
+        val client = SecureSheetWebViewClient(context)
+        client.onPageStarted(view, "DATA:text/html,test", null)
+
+        verify { view.stopLoading() }
+    }
+
+    @Test
+    fun `onPageStarted with normal URL does not stop loading`() {
+        val client = SecureSheetWebViewClient(context)
+        client.onPageStarted(view, "https://example.com", null)
+
+        verify(exactly = 0) { view.stopLoading() }
+    }
+
+    @Test
+    fun `onPageStarted with null URL does not stop loading`() {
+        val client = SecureSheetWebViewClient(context)
+        client.onPageStarted(view, null, null)
+
+        verify(exactly = 0) { view.stopLoading() }
+    }
+}

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
@@ -65,6 +65,10 @@ class WebViewSheetContentClientTest {
 
     @Test
     fun `URL with no scheme calls tryOpenWithSystemHandler`() {
+        // Note: the Uri.parse mock in setUp extracts the scheme via substringBefore(':', "").
+        // When no colon is present (no scheme delimiter), substringBefore returns the
+        // missingDelimiterValue "" which then becomes null via ifEmpty — correctly matching
+        // real Android where Uri.parse("example.com/page").scheme == null.
         val client = SecureSheetWebViewClient(context)
         @Suppress("DEPRECATION")
         val result = client.shouldOverrideUrlLoading(view, "example.com/page")

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentClientTest.kt
@@ -64,14 +64,13 @@ class WebViewSheetContentClientTest {
     // ---- shouldOverrideUrlLoading (String overload) ----
 
     @Test
-    fun `null URL returns true and takes no action`() {
+    fun `URL with no scheme calls tryOpenWithSystemHandler`() {
         val client = SecureSheetWebViewClient(context)
         @Suppress("DEPRECATION")
-        val result = client.shouldOverrideUrlLoading(view, null as String?)
+        val result = client.shouldOverrideUrlLoading(view, "example.com/page")
 
         assertTrue(result)
-        verify(exactly = 0) { tryOpenAsAppLink(any(), any()) }
-        verify(exactly = 0) { tryOpenWithSystemHandler(any(), any()) }
+        verify { tryOpenWithSystemHandler(context, "example.com/page") }
     }
 
     @Test
@@ -176,12 +175,12 @@ class WebViewSheetContentClientTest {
 
     @Test
     fun `WebResourceRequest with tel URL calls tryOpenWithSystemHandler`() {
-        val request = mockk<WebResourceRequest>()
-        every { request.url } returns Uri.parse("tel:+15555550100")
-        // Override so parse returns a proper Uri mock for the request URL
-        every { Uri.parse("tel:+15555550100") } returns mockk {
-            every { scheme } returns "tel"
-            every { toString() } returns "tel:+15555550100"
+        // Uri.parse returns a mock from setUp's any() stub (scheme = "tel" already set).
+        // Stub toString() separately to avoid MockK's internal use of toString() during mock construction.
+        val telUri = Uri.parse("tel:+15555550100")
+        every { telUri.toString() } returns "tel:+15555550100"
+        val request = mockk<WebResourceRequest> {
+            every { url } returns telUri
         }
 
         val client = SecureSheetWebViewClient(context)

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentSchemesTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/webview/WebViewSheetContentSchemesTest.kt
@@ -13,6 +13,8 @@
 package com.adobe.marketing.mobile.concierge.ui.webview
 
 import android.net.Uri
+import com.adobe.marketing.mobile.concierge.utils.isAllowedUrlScheme
+import com.adobe.marketing.mobile.concierge.utils.isBlockedUrlScheme
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -41,86 +43,86 @@ class WebViewSheetContentSchemesTest {
     }
 
     @Test
-    fun `isAllowedScheme returns true for https URL`() {
-        assertTrue(WebViewSheetContentSchemes.isAllowedScheme("https://example.com"))
-        assertTrue(WebViewSheetContentSchemes.isAllowedScheme("HTTPS://example.com/path"))
+    fun `isAllowedUrlScheme returns true for https URL`() {
+        assertTrue(isAllowedUrlScheme("https://example.com"))
+        assertTrue(isAllowedUrlScheme("HTTPS://example.com/path"))
     }
 
     @Test
-    fun `isAllowedScheme returns true for http URL`() {
-        assertTrue(WebViewSheetContentSchemes.isAllowedScheme("http://example.com"))
-        assertTrue(WebViewSheetContentSchemes.isAllowedScheme("HTTP://example.com/path?q=1"))
+    fun `isAllowedUrlScheme returns true for http URL`() {
+        assertTrue(isAllowedUrlScheme("http://example.com"))
+        assertTrue(isAllowedUrlScheme("HTTP://example.com/path?q=1"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for null`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme(null))
+    fun `isAllowedUrlScheme returns false for null`() {
+        assertFalse(isAllowedUrlScheme(null))
     }
 
     @Test
-    fun `isAllowedScheme returns false for blank string`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme(""))
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("   "))
+    fun `isAllowedUrlScheme returns false for blank string`() {
+        assertFalse(isAllowedUrlScheme(""))
+        assertFalse(isAllowedUrlScheme("   "))
     }
 
     @Test
-    fun `isAllowedScheme returns false for file scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("file:///android_asset/index.html"))
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("file:///data/local/tmp/file.html"))
+    fun `isAllowedUrlScheme returns false for file scheme`() {
+        assertFalse(isAllowedUrlScheme("file:///android_asset/index.html"))
+        assertFalse(isAllowedUrlScheme("file:///data/local/tmp/file.html"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for content scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("content://com.example.provider/path"))
+    fun `isAllowedUrlScheme returns false for content scheme`() {
+        assertFalse(isAllowedUrlScheme("content://com.example.provider/path"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for javascript scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("javascript:alert(1)"))
+    fun `isAllowedUrlScheme returns false for javascript scheme`() {
+        assertFalse(isAllowedUrlScheme("javascript:alert(1)"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for intent scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("intent://example.com#Intent;end"))
+    fun `isAllowedUrlScheme returns false for intent scheme`() {
+        assertFalse(isAllowedUrlScheme("intent://example.com#Intent;end"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for data scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("data:text/html,<script>alert(1)</script>"))
+    fun `isAllowedUrlScheme returns false for data scheme`() {
+        assertFalse(isAllowedUrlScheme("data:text/html,<script>alert(1)</script>"))
     }
 
     @Test
-    fun `isAllowedScheme returns false for unknown scheme`() {
-        assertFalse(WebViewSheetContentSchemes.isAllowedScheme("custom-scheme://example.com"))
+    fun `isAllowedUrlScheme returns false for unknown scheme`() {
+        assertFalse(isAllowedUrlScheme("custom-scheme://example.com"))
     }
 
     @Test
-    fun `isBlockedScheme returns true for dangerous schemes`() {
-        assertTrue(WebViewSheetContentSchemes.isBlockedScheme("javascript:alert(1)"))
-        assertTrue(WebViewSheetContentSchemes.isBlockedScheme("file:///data/local/tmp/file.html"))
-        assertTrue(WebViewSheetContentSchemes.isBlockedScheme("content://com.example.provider/path"))
-        assertTrue(WebViewSheetContentSchemes.isBlockedScheme("intent://example.com#Intent;end"))
-        assertTrue(WebViewSheetContentSchemes.isBlockedScheme("data:text/html,<script>alert(1)</script>"))
+    fun `isBlockedUrlScheme returns true for dangerous schemes`() {
+        assertTrue(isBlockedUrlScheme("javascript:alert(1)"))
+        assertTrue(isBlockedUrlScheme("file:///data/local/tmp/file.html"))
+        assertTrue(isBlockedUrlScheme("content://com.example.provider/path"))
+        assertTrue(isBlockedUrlScheme("intent://example.com#Intent;end"))
+        assertTrue(isBlockedUrlScheme("data:text/html,<script>alert(1)</script>"))
     }
 
     @Test
-    fun `isBlockedScheme returns false for system schemes`() {
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("mailto:user@example.com"))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("tel:+15555550100"))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("sms:+15555550100"))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("myapp://screen/detail"))
+    fun `isBlockedUrlScheme returns false for system schemes`() {
+        assertFalse(isBlockedUrlScheme("mailto:user@example.com"))
+        assertFalse(isBlockedUrlScheme("tel:+15555550100"))
+        assertFalse(isBlockedUrlScheme("sms:+15555550100"))
+        assertFalse(isBlockedUrlScheme("myapp://screen/detail"))
     }
 
     @Test
-    fun `isBlockedScheme returns false for http and https`() {
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("http://example.com"))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("https://example.com"))
+    fun `isBlockedUrlScheme returns false for http and https`() {
+        assertFalse(isBlockedUrlScheme("http://example.com"))
+        assertFalse(isBlockedUrlScheme("https://example.com"))
     }
 
     @Test
-    fun `isBlockedScheme returns false for null and blank`() {
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme(null))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme(""))
-        assertFalse(WebViewSheetContentSchemes.isBlockedScheme("   "))
+    fun `isBlockedUrlScheme returns false for null and blank`() {
+        assertFalse(isBlockedUrlScheme(null))
+        assertFalse(isBlockedUrlScheme(""))
+        assertFalse(isBlockedUrlScheme("   "))
     }
 }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtilsTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtilsTest.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.concierge.utils
 
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
@@ -21,11 +22,12 @@ import android.content.pm.verify.domain.DomainVerificationManager
 import android.content.pm.verify.domain.DomainVerificationUserState
 import android.os.Build
 import com.adobe.marketing.mobile.services.Log
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.Runs
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
@@ -61,10 +63,17 @@ class AppLinkUtilsTest {
     // ---- tryOpenWithSystemHandler ----
 
     @Test
-    fun `tryOpenWithSystemHandler calls startActivity for the given URL`() {
+    fun `tryOpenWithSystemHandler calls startActivity with FLAG_ACTIVITY_NEW_TASK`() {
+        val intentSlot = slot<Intent>()
+        every { context.startActivity(capture(intentSlot)) } just Runs
+
         tryOpenWithSystemHandler(context, "tel:+15555550100")
 
         verify { context.startActivity(any()) }
+        assertTrue(
+            "Expected FLAG_ACTIVITY_NEW_TASK to be set",
+            intentSlot.captured.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0
+        )
     }
 
     @Test

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtilsTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/utils/AppLinkUtilsTest.kt
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.utils
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.content.pm.verify.domain.DomainVerificationManager
+import android.content.pm.verify.domain.DomainVerificationUserState
+import android.os.Build
+import com.adobe.marketing.mobile.services.Log
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.Runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [tryOpenWithSystemHandler] and the early-exit paths of [tryOpenAsAppLink]
+ * that are API-version agnostic.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppLinkUtilsTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        mockkStatic(Log::class)
+        every { Log.debug(any(), any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    // ---- tryOpenWithSystemHandler ----
+
+    @Test
+    fun `tryOpenWithSystemHandler calls startActivity for the given URL`() {
+        tryOpenWithSystemHandler(context, "tel:+15555550100")
+
+        verify { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenWithSystemHandler does not throw and logs when startActivity throws`() {
+        every { context.startActivity(any()) } throws ActivityNotFoundException("no handler")
+
+        tryOpenWithSystemHandler(context, "tel:+15555550100") // must not propagate exception
+
+        verify { Log.debug(any(), any(), match { it.contains("tryOpenWithSystemHandler failed") }) }
+    }
+
+    // ---- tryOpenAsAppLink: early exits (API-agnostic) ----
+
+    @Test
+    fun `tryOpenAsAppLink returns false for blank URL`() {
+        assertFalse(tryOpenAsAppLink(context, ""))
+        assertFalse(tryOpenAsAppLink(context, "   "))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false for URL with no host`() {
+        // tel: URIs have no host; function must return false before any API-version check
+        assertFalse(tryOpenAsAppLink(context, "tel:+15555550100"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+}
+
+/**
+ * Tests for [tryOpenAsAppLink] on API 31+ (DomainVerificationManager path).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class AppLinkUtilsApi31Test {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        mockkStatic(Log::class)
+        every { Log.debug(any(), any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns true and opens when domain state is VERIFIED`() {
+        setupDomainVerification("example.com", DomainVerificationUserState.DOMAIN_STATE_VERIFIED)
+
+        assertTrue(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns true and opens when domain state is SELECTED`() {
+        setupDomainVerification("example.com", DomainVerificationUserState.DOMAIN_STATE_SELECTED)
+
+        assertTrue(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false and does not open when domain state is NONE`() {
+        setupDomainVerification("example.com", DomainVerificationUserState.DOMAIN_STATE_NONE)
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false when host is absent from hostToStateMap`() {
+        setupDomainVerification("other.com", DomainVerificationUserState.DOMAIN_STATE_VERIFIED)
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false when DomainVerificationManager is null`() {
+        every { context.getSystemService(DomainVerificationManager::class.java) } returns null
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false and logs when getDomainVerificationUserState throws`() {
+        val dvm = mockk<DomainVerificationManager>()
+        every { context.getSystemService(DomainVerificationManager::class.java) } returns dvm
+        every { context.packageName } returns "com.example.app"
+        every { dvm.getDomainVerificationUserState(any()) } throws SecurityException("not allowed")
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify { Log.debug(any(), any(), match { it.contains("getDomainVerificationUserState failed") }) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false and logs when startActivity throws`() {
+        setupDomainVerification("example.com", DomainVerificationUserState.DOMAIN_STATE_VERIFIED)
+        every { context.startActivity(any()) } throws ActivityNotFoundException("no activity")
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify { Log.debug(any(), any(), match { it.contains("tryOpenAsAppLink failed") }) }
+    }
+
+    private fun setupDomainVerification(host: String, state: Int) {
+        val dvm = mockk<DomainVerificationManager>()
+        val userState = mockk<DomainVerificationUserState>()
+        every { context.getSystemService(DomainVerificationManager::class.java) } returns dvm
+        every { context.packageName } returns "com.example.app"
+        every { dvm.getDomainVerificationUserState("com.example.app") } returns userState
+        every { userState.hostToStateMap } returns mapOf(host to state)
+    }
+}
+
+/**
+ * Tests for [tryOpenAsAppLink] on API 30 and below (PackageManager.resolveActivity path).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class AppLinkUtilsApi30Test {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        mockkStatic(Log::class)
+        every { Log.debug(any(), any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns true and opens when resolveActivity matches packageName`() {
+        val resolveInfo = resolveInfoFor("com.example.app")
+        val pm = mockk<PackageManager>()
+        every { context.packageManager } returns pm
+        every { context.packageName } returns "com.example.app"
+        every { pm.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY) } returns resolveInfo
+
+        assertTrue(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false when resolveActivity matches a different package`() {
+        val resolveInfo = resolveInfoFor("com.browser.app")
+        val pm = mockk<PackageManager>()
+        every { context.packageManager } returns pm
+        every { context.packageName } returns "com.example.app"
+        every { pm.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY) } returns resolveInfo
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `tryOpenAsAppLink returns false when resolveActivity returns null`() {
+        val pm = mockk<PackageManager>()
+        every { context.packageManager } returns pm
+        every { pm.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY) } returns null
+
+        assertFalse(tryOpenAsAppLink(context, "https://example.com/page"))
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    private fun resolveInfoFor(packageName: String): ResolveInfo {
+        val activityInfo = ActivityInfo().apply { this.packageName = packageName }
+        return ResolveInfo().apply { this.activityInfo = activityInfo }
+    }
+}

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 moduleName=concierge
-moduleVersion=3.3.0
+moduleVersion=3.3.1
 
 mavenCoreVersion=3.5.0
 mavenEdgeVersion=3.0.2


### PR DESCRIPTION
## Description
Fixes `tel:`, `geo:`, `mailto:`, and other non-http/https scheme links incorrectly opening in the in-app WebView overlay instead of routing to the appropriate system app (phone dialer, maps, mail client, etc.).

Two separate bugs were present:
1. **`handleLinkClick` in `ConciergeChatViewModel`** — links tapped in chat messages fell through to `openWebviewOverlay` for any scheme that was not `http`/`https`, including `tel:` and `geo:`. The logic only checked for App Links (which return `false` immediately for non-web URIs) before defaulting to the WebView.

2. **`SecureSheetWebViewClient` in `WebViewSheetContent`** — non-http/https links clicked *inside* an already-open WebView sheet were launched via `startActivity` without `FLAG_ACTIVITY_NEW_TASK`, causing a silent `AndroidRuntimeException` on some devices when the context was not a direct Activity context.

Additionally, the fix extracts the shared system-dispatch logic into a reusable `tryOpenWithSystemHandler` utility in `AppLinkUtils.kt`, eliminating code duplication between the two call sites and ensuring consistent error logging.

## Related Issue

## Motivation and Context
Users tapping `tel:` links (e.g. store phone numbers) or `geo:` links (e.g. store locations) in chat responses were seeing the in-app WebView open and display a blank or broken page instead of the phone dialer or maps app opening. The root cause was that the link routing logic in `handleLinkClick` had no handling for non-http/https schemes — after `tryOpenAsAppLink` returned `false` (it returns immediately for URIs with no host), all such links fell unconditionally into the WebView overlay.

## How Has This Been Tested?
- Manual testing with the test app
- Added 8 unit tests to `ConciergeChatViewModelTest` covering all branches of `handleLinkClick`:
  - `tel:`, `geo:`, `mailto:` → `tryOpenWithSystemHandler` called, overlay not opened
  - Blocked schemes (`javascript:`) → falls to WebView overlay, system handler not called
  - `https:` non-App-Link → WebView overlay opened
  - `https:` App Link → handled by `tryOpenAsAppLink`, overlay not opened
  - Host callback returning `true` → takes full priority, nothing else called
  - Host callback returning `false` → falls through to normal routing
  - Blank URL → early return, no action

- Added 15 unit tests to `WebViewSheetContentClientTest` (new file) covering `SecureSheetWebViewClient`:
  - Blocked schemes (`javascript:`, `file:`) → no action, returns `true`
  - `http`/`https` App Link and non-App-Link → correct return value and delegation
  - `tel:`, `geo:`, `mailto:`, custom app scheme → `tryOpenWithSystemHandler` called
  - `WebResourceRequest` overload with tel URL and null URL
  - `onPageStarted` `data:` URL safety net (stop loading, goBack/loadUrl fallback, case-insensitivity)
  - `onPageStarted` with normal and null URLs

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
