### PR TITLE
Feedback dialog theming and behavior tokens

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -263,7 +263,7 @@ Feature toggles and interaction configuration.
 
 | JSON Key | Type | Default | Description |
 |----------|------|---------|-------------|
-| `behavior.chat.messageAlignment` | string | `"start"` | Agent message alignment (`"start"`, `"center"`, `"end"`). Note: theme JSONs using legacy `"left"` values are treated as `"start"`. |
+| `behavior.chat.messageAlignment` | `ConciergeTextAlignment` | `"start"` | Agent message alignment. Accepts `"start"` / `"leading"` / `"left"`, `"center"` / `"justify"`, or `"end"` / `"trailing"` / `"right"`. Case-insensitive; unknown values fall back to `"start"`. |
 | `behavior.chat.messageWidth` | string | `"100%"` | Max message width (e.g., `"100%"`, `"768px"`) |
 | `behavior.chat.userMessageBubbleStyle` | string | `"default"` | User message bubble shape. `"default"` = all corners rounded; `"balloon"` = rounded except bottom-right corner is square (speech balloon style). Corner radius is controlled by `--message-border-radius` (default `12dp`). |
 
@@ -278,8 +278,11 @@ Feature toggles and interaction configuration.
 
 | JSON Key | Type | Default | Description |
 |----------|------|---------|-------------|
-| `behavior.feedback.displayMode` | string | `"modal"` | Feedback dialog display mode. `"modal"` renders inline as a Modal overlay; `"action"` renders as an ActionSheet. |
+| `behavior.feedback.displayMode` | string | `"modal"` | Feedback dialog display mode. `"modal"` renders a centered modal card; `"action"` renders a ModalBottomSheet. |
 | `behavior.feedback.thumbsPlacement` | string | `"inline"` | Thumbs up/down placement. `"inline"` places thumbs beside the sources label; `"below"` places them below the sources accordion with an optional label. |
+| `behavior.feedback.showCloseButton` | boolean \| null | `null` | X close button visibility. `null` = shown for `"action"`, hidden for `"modal"`. |
+| `behavior.feedback.showCancelButton` | boolean \| null | `null` | Cancel button visibility. `null` = shown for `"modal"`, hidden for `"action"`. Both set to `false` is honored: Submit and (in action mode) drag-down still dismiss. |
+| `behavior.feedback.showNotes` | boolean \| null | `null` | Notes field visibility override for modal mode. `null` falls back to per-sentiment `positiveNotesEnabled` / `negativeNotesEnabled`. Not rendered in action mode. |
 
 ### Citations
 
@@ -335,7 +338,10 @@ Feature toggles and interaction configuration.
     },
     "feedback": {
       "displayMode": "action",
-      "thumbsPlacement": "below"
+      "thumbsPlacement": "below",
+      "showCloseButton": true,
+      "showCancelButton": false,
+      "showNotes": null
     },
     "citations": {
       "showLinkIcon": true
@@ -681,6 +687,27 @@ Visual styling using CSS-like variable names. All properties in the `theme` obje
 | `--feedback-icon-btn-background` | `colors.feedback.iconButtonBackground` | `String` | `"#FFFFFF"` | Feedback button background (hex) |
 | `--feedback-icon-btn-hover-background` | `colors.feedback.iconButtonHoverBackground` | `String` | `"#F5F5F5"` | Feedback button hover background (hex) |
 
+#### Feedback Dialog Colors
+
+These tokens style the feedback dialog (modal card and action bottom sheet).
+
+| CSS Variable | Kotlin Property | Type | Default | Description |
+|--------------|-----------------|------|---------|-------------|
+| `--feedback-sheet-background-color` | `colors.feedback.sheetBackground` | `String?` | falls back to `colors.background` | Dialog background fill; also applied to the notes editor. |
+| `--feedback-title-text-color` | `colors.feedback.titleText` | `String?` | falls back to `colors.onBackground` / `colors.primary.text` | Dialog title color. |
+| `--feedback-question-text-color` | `colors.feedback.questionText` | `String?` | falls back to the title color | Dialog question color. |
+| `--feedback-options-text-color` | `colors.feedback.optionsText` | `String?` | falls back to the title color | Checkbox option label color. |
+| `--feedback-checkbox-border-color` | `colors.feedback.checkboxBorder` | `String?` | `"#7F7F7F"` (light) / `"#B0B0B0"` (dark) | Checkbox unchecked outline color. Also used for the notes editor outline. |
+| `--feedback-notes-text-color` | `colors.feedback.notesText` | `String?` | falls back to the title color | Notes label, entered text, and placeholder color. |
+| `--feedback-drag-handle-color` | `colors.feedback.dragHandle` | `String?` | `"#CCCCCC"` | Drag handle color. Only visible in action mode. |
+| `--feedback-submit-button-fill-color` | `colors.feedback.submitButtonFill` | `String?` | falls back to `colors.button.primaryBackground` | Submit button fill color. |
+| `--feedback-submit-button-text-color` | `colors.feedback.submitButtonText` | `String?` | falls back to `colors.button.primaryText` | Submit button text color. |
+| `--feedback-cancel-button-fill-color` | `colors.feedback.cancelButtonFill` | `String?` | `null` (transparent; outline style) | Cancel button fill. `null` = transparent (outline style). Also tints the X close icon. |
+| `--feedback-cancel-button-text-color` | `colors.feedback.cancelButtonText` | `String?` | falls back to `colors.button.secondaryText` | Cancel button label color. |
+| `--feedback-cancel-button-border-color` | `colors.feedback.cancelButtonBorder` | `String?` | falls back to `colors.button.secondaryBorder` | Cancel button outline color. |
+
+> **Contrast note:** When `--feedback-sheet-background-color` is pinned, also set `--feedback-title-text-color`, `--feedback-question-text-color`, `--feedback-options-text-color`, and `--feedback-notes-text-color` to maintain text contrast. System defaults track the device palette, not the themed surface.
+
 ### Colors - Disclaimer
 
 | CSS Variable | Kotlin Property | Type | Default | Description |
@@ -796,6 +823,31 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
 |--------------|-----------------|------|---------|-------------|
 | `--feedback-container-gap` | `cssLayout.feedbackContainerGap` | `Double` | `4.0` | Gap between feedback buttons (dp) |
 | `--feedback-icon-btn-size-desktop` | `components.feedback.iconButtonSizeDesktop` | `Double` | `32.0` | Feedback button hit target size (dp) |
+
+#### Feedback Dialog Layout
+
+These tokens style the feedback dialog layout (modal card and action bottom sheet).
+
+| CSS Variable | Kotlin Property | Type | Default | Description |
+|--------------|-----------------|------|---------|-------------|
+| `--feedback-submit-button-border-radius` | `cssLayout.feedbackSubmitButtonBorderRadius` | `Double?` | `10.0` | Submit button corner radius (dp). |
+| `--feedback-cancel-button-border-radius` | `cssLayout.feedbackCancelButtonBorderRadius` | `Double?` | `10.0` | Cancel button corner radius (dp). |
+| `--feedback-cancel-button-border-width` | `cssLayout.feedbackCancelButtonBorderWidth` | `Double?` | `1.0` | Cancel button outline width (dp). |
+| `--feedback-submit-button-font-weight` | `cssLayout.feedbackSubmitButtonFontWeight` | `Int?` | `600` | Submit button label font weight. |
+| `--feedback-cancel-button-font-weight` | `cssLayout.feedbackCancelButtonFontWeight` | `Int?` | `600` | Cancel button label font weight. |
+| `--feedback-checkbox-border-radius` | `cssLayout.feedbackCheckboxBorderRadius` | `Double?` | `6.0` | Checkbox corner radius (dp). Also used for the notes editor corner radius. |
+| `--feedback-title-text-align` | `cssLayout.feedbackTitleTextAlign` | `ConciergeTextAlignment?` | `null` (`START`) | Feedback dialog title alignment. Accepts `"start"` / `"leading"` / `"left"`, `"center"` / `"justify"`, or `"end"` / `"trailing"` / `"right"`. Case-insensitive; unknown values fall back to `START`. |
+| `--feedback-title-font-size` | `cssLayout.feedbackTitleFontSize` | `Double?` | `22.0` | Title font size (sp). |
+
+### Components - Feedback
+
+Non-CSS `components.feedback` overrides for the feedback dialog.
+
+| JSON Key | Type | Default | Description |
+|----------|------|---------|-------------|
+| `components.feedback.iconButtonSizeDesktop` | number | `32` | Feedback icon button hit target size (dp). Mirrors `--feedback-icon-btn-size-desktop`. |
+| `components.feedback.positiveNotesEnabled` | boolean | `true` | Notes field visibility for positive-sentiment modal. Overridden by `behavior.feedback.showNotes`. Not applied in action mode. |
+| `components.feedback.negativeNotesEnabled` | boolean | `true` | Notes field visibility for negative-sentiment modal. Overridden by `behavior.feedback.showNotes`. Not applied in action mode. |
 
 ### Layout - Citations
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/feedback/FeedbackDialog.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/feedback/FeedbackDialog.kt
@@ -12,6 +12,7 @@
 
 package com.adobe.marketing.mobile.concierge.ui.components.feedback
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,10 +40,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -53,13 +54,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.R
 import com.adobe.marketing.mobile.concierge.ui.state.Feedback
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackType
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeFeedbackBehavior
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
 import com.adobe.marketing.mobile.concierge.ui.theme.FeedbackDisplayMode
@@ -149,6 +149,35 @@ private fun resolveQuestion(feedbackType: FeedbackType): String {
     }
 }
 
+/** Notes field visibility: `showNotes` when set, otherwise per-sentiment `positive/negativeNotesEnabled`. */
+@Composable
+private fun resolveNotesEnabled(feedbackType: FeedbackType): Boolean {
+    val componentsFeedback = ConciergeTheme.tokens?.components?.feedback
+    val sentimentFallback = if (feedbackType == FeedbackType.POSITIVE) {
+        componentsFeedback?.positiveNotesEnabled ?: true
+    } else {
+        componentsFeedback?.negativeNotesEnabled ?: true
+    }
+    val behavior: ConciergeFeedbackBehavior? = ConciergeTheme.behavior?.feedback
+    return behavior?.resolvedShowNotes(sentimentFallback) ?: sentimentFallback
+}
+
+/** Close (X) button visibility: `true` for `"action"`, `false` for `"modal"` by default. */
+@Composable
+private fun resolveShowCloseButton(): Boolean {
+    val behavior = ConciergeTheme.behavior?.feedback
+    return behavior?.resolvedShowCloseButton()
+        ?: (ConciergeTheme.behavior?.feedback?.displayMode == FeedbackDisplayMode.ACTION)
+}
+
+/** Cancel button visibility: `true` for `"modal"`, `false` for `"action"` by default. */
+@Composable
+private fun resolveShowCancelButton(): Boolean {
+    val behavior = ConciergeTheme.behavior?.feedback
+    return behavior?.resolvedShowCancelButton()
+        ?: (ConciergeTheme.behavior?.feedback?.displayMode != FeedbackDisplayMode.ACTION)
+}
+
 // --- Shared UI components ---
 
 /**
@@ -161,30 +190,150 @@ private fun CategoryCheckboxList(
     onToggle: (String) -> Unit,
     style: ConciergeStyles.FeedbackDialogStyle
 ) {
-    categories.forEach { category ->
-        Row(
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(style.categorySpacing)
+    ) {
+        categories.forEach { category ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggle(category) },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = category in selectedCategories,
+                    onCheckedChange = null,
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = style.checkboxCheckedColor,
+                        checkmarkColor = style.checkboxCheckmarkColor,
+                        uncheckedColor = style.checkboxUncheckedColor
+                    )
+                )
+                Spacer(modifier = Modifier.width(style.checkboxSpacing))
+                Text(
+                    text = category,
+                    style = style.categoryTextStyle,
+                    color = style.categoryTextColor,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Dialog title row with an optional trailing X close button. Shared by card and sheet.
+ */
+@Composable
+private fun FeedbackTitleRow(
+    titleText: String,
+    showCloseButton: Boolean,
+    onDismiss: () -> Unit,
+    style: ConciergeStyles.FeedbackDialogStyle
+) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        val titlePadding = if (showCloseButton) Modifier.padding(end = 40.dp) else Modifier
+        Text(
+            text = titleText,
+            style = style.titleStyle,
+            color = style.titleColor,
+            textAlign = style.titleTextAlign,
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onToggle(category) },
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Checkbox(
-                checked = category in selectedCategories,
-                onCheckedChange = null,
-                colors = CheckboxDefaults.colors(
-                    checkedColor = style.checkboxCheckedColor,
-                    checkmarkColor = style.checkboxCheckmarkColor,
-                    uncheckedColor = style.checkboxUncheckedColor
+                .then(titlePadding)
+        )
+        if (showCloseButton) {
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .size(32.dp)
+                    .align(Alignment.CenterEnd)
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.close),
+                    contentDescription = "Close",
+                    tint = style.closeIconTint,
+                    modifier = Modifier.size(18.dp)
                 )
+            }
+        }
+    }
+}
+
+/** Cancel + Submit button row, honoring `showCancelButton` and the resolved button styles. */
+@Composable
+private fun FeedbackActionButtons(
+    showCancelButton: Boolean,
+    onCancel: () -> Unit,
+    onSubmit: () -> Unit,
+    style: ConciergeStyles.FeedbackDialogStyle
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(style.buttonSpacing),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val themeText = ConciergeTheme.text
+        if (showCancelButton) {
+            OutlinedButton(
+                onClick = onCancel,
+                shape = style.cancelButtonShape,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(44.dp),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    containerColor = style.cancelButtonFill,
+                    contentColor = style.cancelButtonColor
+                ),
+                border = androidx.compose.foundation.BorderStroke(
+                    width = style.cancelButtonBorderWidth,
+                    color = style.cancelButtonBorderColor
+                )
+            ) {
+                Text(
+                    text = themeText?.feedbackDialogCancel ?: "Cancel",
+                    style = style.buttonTextStyle.copy(fontWeight = style.cancelButtonFontWeight)
+                )
+            }
+        }
+
+        Button(
+            onClick = onSubmit,
+            shape = style.submitButtonShape,
+            modifier = Modifier
+                .weight(1f)
+                .height(44.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = style.submitButtonColor,
+                contentColor = style.submitButtonTextColor
             )
-            Spacer(modifier = Modifier.width(style.checkboxSpacing))
+        ) {
             Text(
-                text = category,
-                style = style.categoryTextStyle,
-                color = style.categoryTextColor,
-                modifier = Modifier.weight(1f)
+                text = themeText?.feedbackDialogSubmit ?: "Submit",
+                style = style.buttonTextStyle.copy(fontWeight = style.submitButtonFontWeight),
+                color = style.submitButtonTextColor
             )
         }
+    }
+}
+
+/**
+ * Themable drag-handle capsule used in action (bottom sheet) mode.
+ */
+@Composable
+private fun FeedbackDragHandle(style: ConciergeStyles.FeedbackDialogStyle) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp, bottom = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 36.dp, height = 4.dp)
+                .background(color = style.dragHandleColor, shape = RoundedCornerShape(2.dp))
+        )
     }
 }
 
@@ -220,7 +369,8 @@ private fun FeedbackDialogCard(
 }
 
 /**
- * Card content: title, question, categories, notes field, Cancel/Submit buttons.
+ * Card content: title, optional close X, question, categories, optional notes field,
+ * and the Cancel/Submit action row. Visibility toggles honor `behavior.feedback.show*`.
  */
 @Composable
 private fun FeedbackCardContent(
@@ -235,23 +385,23 @@ private fun FeedbackCardContent(
     val titleText = resolveTitle(feedback.feedbackType)
     val questionText = resolveQuestion(feedback.feedbackType)
     val categories = resolveCategories(feedback.feedbackType)
+    val showNotes = resolveNotesEnabled(feedback.feedbackType)
+    val showCloseButton = resolveShowCloseButton()
+    val showCancelButton = resolveShowCancelButton()
 
     var selectedCategories by remember { mutableStateOf(setOf<String>()) }
     var notesText by remember { mutableStateOf("") }
 
     Column(modifier = modifier) {
-        // Title
-        Text(
-            text = titleText,
-            style = style.titleStyle,
-            color = style.titleColor,
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center
+        FeedbackTitleRow(
+            titleText = titleText,
+            showCloseButton = showCloseButton,
+            onDismiss = onDismiss,
+            style = style
         )
 
         Spacer(modifier = Modifier.height(style.titleSpacing))
 
-        // Question
         Text(
             text = questionText,
             style = style.questionStyle,
@@ -261,7 +411,6 @@ private fun FeedbackCardContent(
 
         Spacer(modifier = Modifier.height(style.questionSpacing))
 
-        // Categories
         CategoryCheckboxList(
             categories = categories,
             selectedCategories = selectedCategories,
@@ -275,79 +424,61 @@ private fun FeedbackCardContent(
             style = style
         )
 
-        Spacer(modifier = Modifier.height(style.categoriesNotesSpacing))
+        if (showNotes) {
+            Spacer(modifier = Modifier.height(style.categoriesNotesSpacing))
 
-        // Notes section
-        Text(
-            text = themeText?.feedbackDialogNotes ?: "Notes",
-            style = style.notesLabelStyle,
-            color = style.notesLabelColor,
-            modifier = Modifier.fillMaxWidth()
-        )
+            Text(
+                text = themeText?.feedbackDialogNotes ?: "Notes",
+                style = style.notesLabelStyle,
+                color = style.notesLabelColor,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        Spacer(modifier = Modifier.height(style.notesLabelSpacing))
+            Spacer(modifier = Modifier.height(style.notesLabelSpacing))
 
-        OutlinedTextField(
-            value = notesText,
-            onValueChange = { notesText = it },
-            modifier = Modifier.fillMaxWidth(),
-            placeholder = {
-                Text(
-                    text = themeText?.feedbackDialogNotesPlaceholder ?: "Add any additional comments...",
-                    style = style.notesPlaceholderStyle,
-                    color = style.notesPlaceholderColor
-                )
-            },
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = style.textFieldBorderColor,
-                unfocusedBorderColor = style.textFieldBorderColor.copy(alpha = 0.5f),
-                focusedTextColor = style.textFieldTextColor,
-                unfocusedTextColor = style.textFieldTextColor
-            ),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-            maxLines = 3
-        )
+            OutlinedTextField(
+                value = notesText,
+                onValueChange = { notesText = it },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = themeText?.feedbackDialogNotesPlaceholder ?: "Add any additional comments...",
+                        style = style.notesPlaceholderStyle,
+                        color = style.notesPlaceholderColor
+                    )
+                },
+                shape = style.checkboxShape,
+                colors = OutlinedTextFieldDefaults.colors(
+                    // Notes fill matches the sheet/card surface.
+                    focusedContainerColor = style.backgroundColor,
+                    unfocusedContainerColor = style.backgroundColor,
+                    // Notes outline matches the checkbox outline when themed.
+                    focusedBorderColor = style.textFieldBorderColor,
+                    unfocusedBorderColor = style.textFieldBorderColor,
+                    focusedTextColor = style.textFieldTextColor,
+                    unfocusedTextColor = style.textFieldTextColor
+                ),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                maxLines = 3
+            )
+        }
 
         Spacer(modifier = Modifier.height(style.notesButtonsSpacing))
 
-        // Action buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            TextButton(
-                onClick = onDismiss,
-                colors = ButtonDefaults.textButtonColors(contentColor = style.cancelButtonColor)
-            ) {
-                Text(
-                    text = themeText?.feedbackDialogCancel ?: "Cancel",
-                    style = style.buttonTextStyle
-                )
-            }
-
-            Spacer(modifier = Modifier.width(style.buttonSpacing))
-
-            Button(
-                onClick = {
-                    onSubmit(
-                        feedback.copy(
-                            selectedCategories = selectedCategories.toList(),
-                            notes = notesText.trim()
-                        )
+        FeedbackActionButtons(
+            showCancelButton = showCancelButton,
+            onCancel = onDismiss,
+            onSubmit = {
+                onSubmit(
+                    feedback.copy(
+                        selectedCategories = selectedCategories.toList(),
+                        notes = if (showNotes) notesText.trim() else ""
                     )
-                },
-                colors = ButtonDefaults.buttonColors(containerColor = style.submitButtonColor),
-                enabled = selectedCategories.isNotEmpty() || notesText.isNotBlank()
-            ) {
-                Text(
-                    text = themeText?.feedbackDialogSubmit ?: "Submit",
-                    style = style.buttonTextStyle,
-                    color = style.submitButtonTextColor
                 )
-            }
-        }
+            },
+            style = style
+        )
     }
 }
 
@@ -369,7 +500,8 @@ private fun FeedbackDialogBottomSheet(
         sheetState = sheetState,
         shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
         containerColor = style.backgroundColor,
-        dragHandle = null,
+        // Themable capsule handle replaces Material3's default.
+        dragHandle = { FeedbackDragHandle(style) },
         modifier = modifier
     ) {
         FeedbackBottomSheetContent(
@@ -384,8 +516,8 @@ private fun FeedbackDialogBottomSheet(
 }
 
 /**
- * Bottom sheet content: title with close button, question, categories, full-width SUBMIT button.
- * Enabled via `behavior.feedback.displayMode: "action"` in theme JSON.
+ * Bottom sheet content: title (with optional X close), question, categories, and action buttons.
+ * The notes field is intentionally not rendered in action mode; submitted `notes` is always `""`.
  */
 @Composable
 private fun FeedbackBottomSheetContent(
@@ -395,45 +527,24 @@ private fun FeedbackBottomSheetContent(
     onSubmit: (Feedback) -> Unit
 ) {
     val style = ConciergeStyles.feedbackDialogStyle
-    val themeText = ConciergeTheme.text
     val titleText = resolveTitle(feedback.feedbackType)
     val questionText = resolveQuestion(feedback.feedbackType)
     val categories = resolveCategories(feedback.feedbackType)
+    val showCloseButton = resolveShowCloseButton()
+    val showCancelButton = resolveShowCancelButton()
 
     var selectedCategories by remember { mutableStateOf(setOf<String>()) }
 
     Column(modifier = modifier.padding(horizontal = style.contentPadding)) {
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Header: title + close button
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = titleText,
-                style = style.titleStyle,
-                color = style.titleColor,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(end = 40.dp),
-                textAlign = TextAlign.Center
-            )
-            IconButton(
-                onClick = onDismiss,
-                modifier = Modifier
-                    .size(32.dp)
-                    .align(Alignment.CenterEnd)
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.close),
-                    contentDescription = "Close",
-                    tint = style.titleColor,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-        }
+        FeedbackTitleRow(
+            titleText = titleText,
+            showCloseButton = showCloseButton,
+            onDismiss = onDismiss,
+            style = style
+        )
 
         Spacer(modifier = Modifier.height(style.titleSpacing))
 
-        // Question
         Text(
             text = questionText,
             style = style.questionStyle,
@@ -443,7 +554,6 @@ private fun FeedbackBottomSheetContent(
 
         Spacer(modifier = Modifier.height(style.questionSpacing))
 
-        // Categories
         CategoryCheckboxList(
             categories = categories,
             selectedCategories = selectedCategories,
@@ -457,11 +567,12 @@ private fun FeedbackBottomSheetContent(
             style = style
         )
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(style.notesButtonsSpacing))
 
-        // Full-width SUBMIT button
-        Button(
-            onClick = {
+        FeedbackActionButtons(
+            showCancelButton = showCancelButton,
+            onCancel = onDismiss,
+            onSubmit = {
                 onSubmit(
                     feedback.copy(
                         selectedCategories = selectedCategories.toList(),
@@ -469,19 +580,8 @@ private fun FeedbackBottomSheetContent(
                     )
                 )
             },
-            colors = ButtonDefaults.buttonColors(containerColor = style.submitButtonColor),
-            enabled = selectedCategories.isNotEmpty(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            shape = RoundedCornerShape(8.dp)
-        ) {
-            Text(
-                text = (themeText?.feedbackDialogSubmit ?: "Submit").uppercase(),
-                style = style.buttonTextStyle.copy(fontWeight = FontWeight.Bold),
-                color = style.submitButtonTextColor
-            )
-        }
+            style = style
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
     }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -43,20 +43,15 @@ import com.adobe.marketing.mobile.concierge.ui.components.suggestions.PromptSugg
 import com.adobe.marketing.mobile.concierge.ui.state.ChatMessage
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackEvent
 import com.adobe.marketing.mobile.concierge.ui.state.MessageContent
-import com.adobe.marketing.mobile.concierge.ui.theme.ChatMessageAlignment
+import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTextAlignment
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
 
-/**
- * Maps a [ChatMessageAlignment] to the Compose [Modifier] that produces the correct
- * horizontal alignment for a bot message card. The pattern is consistent across all
- * render functions: [fillMaxWidth] reserves the full layout slot so the list is stable,
- * and [wrapContentWidth] then shrinks the card to its content and anchors it.
- */
-private fun ChatMessageAlignment.toModifier(): Modifier = when (this) {
-    ChatMessageAlignment.CENTER -> Modifier.fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally)
-    ChatMessageAlignment.END -> Modifier.fillMaxWidth().wrapContentWidth(Alignment.End)
-    ChatMessageAlignment.START -> Modifier.fillMaxWidth()
+/** Maps [ConciergeTextAlignment] to the [Modifier] that horizontally aligns a bot message card. */
+private fun ConciergeTextAlignment.toModifier(): Modifier = when (this) {
+    ConciergeTextAlignment.CENTER -> Modifier.fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally)
+    ConciergeTextAlignment.END -> Modifier.fillMaxWidth().wrapContentWidth(Alignment.End)
+    ConciergeTextAlignment.START -> Modifier.fillMaxWidth()
 }
 
 /**
@@ -122,7 +117,7 @@ private fun RenderTextMessage(
     val thinkingStyle = ConciergeStyles.thinkingAnimationStyle
     val isThinking = message.isThinking
     val companyIconName = if (!message.isFromUser) ConciergeTheme.tokens?.assets?.icons?.company?.takeIf { it.isNotEmpty() } else null
-    val messageAlignment = ConciergeTheme.behavior?.chat?.messageAlignment ?: ChatMessageAlignment.START
+    val messageAlignment = ConciergeTheme.behavior?.chat?.messageAlignment ?: ConciergeTextAlignment.START
 
     if (companyIconName != null) {
         RenderTextMessageWithIcon(
@@ -313,7 +308,7 @@ private fun RenderMixedMessage(
     val style = ConciergeStyles.messageBubbleStyle
     val content = message.content as MessageContent.Mixed
     val companyIconName = if (!message.isFromUser) ConciergeTheme.tokens?.assets?.icons?.company?.takeIf { it.isNotEmpty() } else null
-    val messageAlignment = ConciergeTheme.behavior?.chat?.messageAlignment ?: ChatMessageAlignment.START
+    val messageAlignment = ConciergeTheme.behavior?.chat?.messageAlignment ?: ConciergeTextAlignment.START
 
     Column(
         modifier = Modifier

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -310,7 +310,67 @@ internal object CSSKeyMapper {
                 existing?.copy(iconButtonHoverBackground = color) ?: ConciergeFeedbackColors(iconButtonHoverBackground = color)
             }
         },
-        
+        "feedback-sheet-background-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(sheetBackground = color) ?: ConciergeFeedbackColors(sheetBackground = color)
+            }
+        },
+        "feedback-title-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(titleText = color) ?: ConciergeFeedbackColors(titleText = color)
+            }
+        },
+        "feedback-question-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(questionText = color) ?: ConciergeFeedbackColors(questionText = color)
+            }
+        },
+        "feedback-options-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(optionsText = color) ?: ConciergeFeedbackColors(optionsText = color)
+            }
+        },
+        "feedback-checkbox-border-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(checkboxBorder = color) ?: ConciergeFeedbackColors(checkboxBorder = color)
+            }
+        },
+        "feedback-notes-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(notesText = color) ?: ConciergeFeedbackColors(notesText = color)
+            }
+        },
+        "feedback-drag-handle-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(dragHandle = color) ?: ConciergeFeedbackColors(dragHandle = color)
+            }
+        },
+        "feedback-submit-button-fill-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(submitButtonFill = color) ?: ConciergeFeedbackColors(submitButtonFill = color)
+            }
+        },
+        "feedback-submit-button-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(submitButtonText = color) ?: ConciergeFeedbackColors(submitButtonText = color)
+            }
+        },
+        "feedback-cancel-button-fill-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(cancelButtonFill = color) ?: ConciergeFeedbackColors(cancelButtonFill = color)
+            }
+        },
+        "feedback-cancel-button-text-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(cancelButtonText = color) ?: ConciergeFeedbackColors(cancelButtonText = color)
+            }
+        },
+        "feedback-cancel-button-border-color" to { cssValue, theme ->
+            updateFeedbackColors(cssValue, theme) { existing, color ->
+                existing?.copy(cancelButtonBorder = color) ?: ConciergeFeedbackColors(cancelButtonBorder = color)
+            }
+        },
+
         // Colors - Disclaimer
         "disclaimer-color" to { cssValue, theme ->
             val color = CSSValueConverter.parseColor(cssValue)
@@ -505,7 +565,63 @@ internal object CSSKeyMapper {
                 layout?.copy(feedbackContainerGap = gap) ?: ConciergeLayout(feedbackContainerGap = gap)
             }
         },
-        
+        "feedback-submit-button-border-radius" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val radius = CSSValueConverter.parsePxValue(cssValue) ?: 10.0
+                layout?.copy(feedbackSubmitButtonBorderRadius = radius)
+                    ?: ConciergeLayout(feedbackSubmitButtonBorderRadius = radius)
+            }
+        },
+        "feedback-submit-button-font-weight" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val weight = CSSValueConverter.parseFontWeight(cssValue)
+                layout?.copy(feedbackSubmitButtonFontWeight = weight)
+                    ?: ConciergeLayout(feedbackSubmitButtonFontWeight = weight)
+            }
+        },
+        "feedback-cancel-button-border-radius" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val radius = CSSValueConverter.parsePxValue(cssValue) ?: 10.0
+                layout?.copy(feedbackCancelButtonBorderRadius = radius)
+                    ?: ConciergeLayout(feedbackCancelButtonBorderRadius = radius)
+            }
+        },
+        "feedback-cancel-button-border-width" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val width = CSSValueConverter.parsePxValue(cssValue) ?: 1.0
+                layout?.copy(feedbackCancelButtonBorderWidth = width)
+                    ?: ConciergeLayout(feedbackCancelButtonBorderWidth = width)
+            }
+        },
+        "feedback-cancel-button-font-weight" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val weight = CSSValueConverter.parseFontWeight(cssValue)
+                layout?.copy(feedbackCancelButtonFontWeight = weight)
+                    ?: ConciergeLayout(feedbackCancelButtonFontWeight = weight)
+            }
+        },
+        "feedback-checkbox-border-radius" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val radius = CSSValueConverter.parsePxValue(cssValue) ?: 6.0
+                layout?.copy(feedbackCheckboxBorderRadius = radius)
+                    ?: ConciergeLayout(feedbackCheckboxBorderRadius = radius)
+            }
+        },
+        "feedback-title-text-align" to { cssValue, theme ->
+            val alignment = ConciergeTextAlignment.fromString(cssValue)
+            updateLayout(theme) { layout ->
+                layout?.copy(feedbackTitleTextAlign = alignment)
+                    ?: ConciergeLayout(feedbackTitleTextAlign = alignment)
+            }
+        },
+        "feedback-title-font-size" to { cssValue, theme ->
+            updateLayout(theme) { layout ->
+                val size = CSSValueConverter.parsePxValue(cssValue)
+                layout?.copy(feedbackTitleFontSize = size)
+                    ?: ConciergeLayout(feedbackTitleFontSize = size)
+            }
+        },
+
         // Layout - Citations
         "citations-text-font-weight" to { cssValue, theme ->
             updateLayout(theme) { layout ->

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -74,11 +74,25 @@ data class ConciergeColors(
     val feedbackIconButtonBackground: Color? = null,
     val feedbackIconButtonHoverBackground: Color? = null,
 
-    // Feedback dialog (rom CSS themes)
+    // Feedback dialog (from CSS themes)
     val feedbackDialogCheckboxCheckedColor: Color? = null,
     val feedbackDialogCancelButtonColor: Color? = null,
     val feedbackDialogSubmitButtonColor: Color? = null,
     val feedbackDialogSubmitButtonTextColor: Color? = null,
+
+    // Feedback dialog - extended styling (from CSS themes)
+    val feedbackSheetBackground: Color? = null,
+    val feedbackTitleText: Color? = null,
+    val feedbackQuestionText: Color? = null,
+    val feedbackOptionsText: Color? = null,
+    val feedbackCheckboxBorder: Color? = null,
+    val feedbackNotesText: Color? = null,
+    val feedbackDragHandle: Color? = null,
+    val feedbackSubmitButtonFill: Color? = null,
+    val feedbackSubmitButtonText: Color? = null,
+    val feedbackCancelButtonFill: Color? = null,
+    val feedbackCancelButtonText: Color? = null,
+    val feedbackCancelButtonBorder: Color? = null,
 
     // Prompt pill colors (from CSS themes)
     val welcomePromptBackground: Color? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -1049,9 +1049,7 @@ internal object ConciergeStyles {
             padding = 16.dp
         )
 
-    /**
-     * Styling for feedback dialog
-     */
+    /** Styling for the feedback dialog. `backgroundColor` also drives the notes editor fill. */
     @Immutable
     data class FeedbackDialogStyle(
         val padding: Dp,
@@ -1061,6 +1059,7 @@ internal object ConciergeStyles {
         val contentPadding: Dp,
         val titleStyle: TextStyle,
         val titleColor: Color,
+        val titleTextAlign: TextAlign,
         val titleSpacing: Dp,
         val questionStyle: TextStyle,
         val questionColor: Color,
@@ -1069,6 +1068,9 @@ internal object ConciergeStyles {
         val checkboxCheckedColor: Color,
         val checkboxCheckmarkColor: Color,
         val checkboxUncheckedColor: Color,
+        /** Unchecked checkbox outline; also reused for the notes editor outline. */
+        val checkboxBorderColor: Color,
+        val checkboxShape: Shape,
         val checkboxSpacing: Dp,
         val categoryTextStyle: TextStyle,
         val categoryTextColor: Color,
@@ -1083,55 +1085,143 @@ internal object ConciergeStyles {
         val textFieldTextColor: Color,
         val buttonSpacing: Dp,
         val cancelButtonColor: Color,
+        /** Cancel button fill; `Color.Transparent` when unthemed (outline style). */
+        val cancelButtonFill: Color,
+        val cancelButtonBorderColor: Color,
+        val cancelButtonBorderWidth: Dp,
+        val cancelButtonShape: Shape,
+        val cancelButtonFontWeight: FontWeight,
         val submitButtonColor: Color,
         val submitButtonTextColor: Color,
+        val submitButtonShape: Shape,
+        val submitButtonFontWeight: FontWeight,
+        val dragHandleColor: Color,
+        /** Tint of the X close icon; also falls back to cancel fill per iOS. */
+        val closeIconTint: Color,
         val buttonTextStyle: TextStyle
     )
 
     val feedbackDialogStyle: FeedbackDialogStyle
         @Composable get() {
             val themeColors = ConciergeTheme.colors
-            // Use the screen background for the dialog so it is always fully opaque.
-            // conciergeMessageBackground can be semi-transparent (e.g. an overlay tint
-            // for chat bubbles), which causes bleed-through when used on the dialog.
-            val dialogBackground = themeColors.background
+            val cssLayout = ConciergeTheme.tokens?.cssLayout
+            val isDark = isSystemInDarkTheme()
+
+            // Sheet/modal fill. Prefer the explicit feedback sheet background; fall back to the screen background.
+            // Avoid conciergeMessageBackground which may be semi-transparent (chat bubble tint).
+            val sheetBackground = themeColors.feedbackSheetBackground ?: themeColors.background
+
             val dialogTextColor = themeColors.conciergeMessageText ?: themeColors.onSurface
+
             // Checkbox: primary background when checked, white checkmark in both light and dark
             val checkboxCheckedColor = themeColors.feedbackDialogCheckboxCheckedColor ?: themeColors.primary
-            val checkboxCheckmarkColor = Color.White
+
+            // Adaptive unchecked outline when no explicit feedback.checkboxBorder is set.
+            val adaptiveCheckboxBorder = if (isDark) Color.White.copy(alpha = 0.28f) else Color.Black.copy(alpha = 0.35f)
+            val checkboxBorder = themeColors.feedbackCheckboxBorder ?: adaptiveCheckboxBorder
+
+            val titleTextAlign = when (cssLayout?.feedbackTitleTextAlign) {
+                ConciergeTextAlignment.CENTER -> TextAlign.Center
+                ConciergeTextAlignment.END -> TextAlign.End
+                ConciergeTextAlignment.START, null -> TextAlign.Start
+            }
+
+            val titleStyle = MaterialTheme.typography.titleMedium
+                .copy(fontWeight = FontWeight.Bold)
+                .let { base ->
+                    cssLayout?.feedbackTitleFontSize?.let { size -> base.copy(fontSize = size.sp) } ?: base
+                }
+
+            val submitShape = RoundedCornerShape((cssLayout?.feedbackSubmitButtonBorderRadius ?: 10.0).dp)
+            val cancelShape = RoundedCornerShape((cssLayout?.feedbackCancelButtonBorderRadius ?: 10.0).dp)
+            val checkboxShape = RoundedCornerShape((cssLayout?.feedbackCheckboxBorderRadius ?: 6.0).dp)
+            val cancelBorderWidth = (cssLayout?.feedbackCancelButtonBorderWidth ?: 1.0).dp
+
+            val submitFontWeight = cssLayout?.feedbackSubmitButtonFontWeight?.let { FontWeight(it) }
+                ?: FontWeight.SemiBold
+            val cancelFontWeight = cssLayout?.feedbackCancelButtonFontWeight?.let { FontWeight(it) }
+                ?: FontWeight.SemiBold
+
+            val submitFill = themeColors.feedbackSubmitButtonFill
+                ?: themeColors.feedbackDialogSubmitButtonColor
+                ?: themeColors.buttonSubmitFill
+                ?: themeColors.buttonPrimaryBackground
+                ?: themeColors.primary
+            val submitText = themeColors.feedbackSubmitButtonText
+                ?: themeColors.feedbackDialogSubmitButtonTextColor
+                ?: themeColors.buttonSubmitText
+                ?: themeColors.buttonPrimaryText
+                ?: themeColors.onPrimary
+
+            // iOS `nil` fill renders an outline; mirror by defaulting to transparent when unthemed.
+            val cancelFill = themeColors.feedbackCancelButtonFill ?: Color.Transparent
+            val cancelText = themeColors.feedbackCancelButtonText
+                ?: themeColors.feedbackDialogCancelButtonColor
+                ?: themeColors.buttonSecondaryText
+                ?: themeColors.primary
+            val cancelBorder = themeColors.feedbackCancelButtonBorder
+                ?: themeColors.buttonSecondaryBorder
+                ?: dialogTextColor.copy(alpha = 0.2f)
+
+            // Close icon tint: `feedback.cancelButtonFill ?? button.secondaryText`.
+            val closeTint = themeColors.feedbackCancelButtonFill
+                ?: themeColors.buttonSecondaryText
+                ?: dialogTextColor
+
+            val dragHandleColor = themeColors.feedbackDragHandle ?: dialogTextColor.copy(alpha = 0.4f)
+
+            val titleColor = themeColors.feedbackTitleText ?: dialogTextColor
+            val questionColor = themeColors.feedbackQuestionText ?: dialogTextColor.copy(alpha = 0.7f)
+            val categoryTextColor = themeColors.feedbackOptionsText ?: dialogTextColor
+            val notesTextColor = themeColors.feedbackNotesText ?: dialogTextColor.copy(alpha = 0.7f)
+            val notesPlaceholderColor = themeColors.feedbackNotesText ?: dialogTextColor.copy(alpha = 0.5f)
+            // iOS reuses the checkbox outline for the notes editor outline when set.
+            val textFieldBorder = themeColors.feedbackCheckboxBorder ?: dialogTextColor.copy(alpha = 0.2f)
 
             return FeedbackDialogStyle(
                 padding = 16.dp,
-                backgroundColor = dialogBackground,
+                backgroundColor = sheetBackground,
                 elevation = 8.dp,
                 shape = RoundedCornerShape(12.dp),
                 contentPadding = 20.dp,
-                titleStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                titleColor = dialogTextColor,
+                titleStyle = titleStyle,
+                titleColor = titleColor,
+                titleTextAlign = titleTextAlign,
                 titleSpacing = 12.dp,
                 questionStyle = MaterialTheme.typography.bodyMedium,
-                questionColor = dialogTextColor.copy(alpha = 0.7f),
+                questionColor = questionColor,
                 questionSpacing = 6.dp,
-                categorySpacing = 0.dp,
+                categorySpacing = 12.dp,
                 checkboxCheckedColor = checkboxCheckedColor,
-                checkboxCheckmarkColor = checkboxCheckmarkColor,
-                checkboxUncheckedColor = dialogTextColor.copy(alpha = 0.3f),
+                checkboxCheckmarkColor = Color.White,
+                checkboxUncheckedColor = checkboxBorder,
+                checkboxBorderColor = checkboxBorder,
+                checkboxShape = checkboxShape,
                 checkboxSpacing = 8.dp,
                 categoryTextStyle = MaterialTheme.typography.bodyMedium,
-                categoryTextColor = dialogTextColor,
+                categoryTextColor = categoryTextColor,
                 categoriesNotesSpacing = 6.dp,
                 notesLabelStyle = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                notesLabelColor = dialogTextColor.copy(alpha = 0.7f),
+                notesLabelColor = notesTextColor,
                 notesLabelSpacing = 8.dp,
                 notesPlaceholderStyle = MaterialTheme.typography.bodyMedium,
-                notesPlaceholderColor = dialogTextColor.copy(alpha = 0.5f),
+                notesPlaceholderColor = notesPlaceholderColor,
                 notesButtonsSpacing = 24.dp,
-                textFieldBorderColor = dialogTextColor.copy(alpha = 0.2f),
+                textFieldBorderColor = textFieldBorder,
                 textFieldTextColor = dialogTextColor,
                 buttonSpacing = 8.dp,
-                cancelButtonColor = themeColors.feedbackDialogCancelButtonColor ?: themeColors.primary,
-                submitButtonColor = themeColors.feedbackDialogSubmitButtonColor ?: themeColors.buttonSubmitFill ?: themeColors.primary,
-                submitButtonTextColor = themeColors.feedbackDialogSubmitButtonTextColor ?: themeColors.buttonSubmitText ?: themeColors.onPrimary,
+                cancelButtonColor = cancelText,
+                cancelButtonFill = cancelFill,
+                cancelButtonBorderColor = cancelBorder,
+                cancelButtonBorderWidth = cancelBorderWidth,
+                cancelButtonShape = cancelShape,
+                cancelButtonFontWeight = cancelFontWeight,
+                submitButtonColor = submitFill,
+                submitButtonTextColor = submitText,
+                submitButtonShape = submitShape,
+                submitButtonFontWeight = submitFontWeight,
+                dragHandleColor = dragHandleColor,
+                closeIconTint = closeTint,
                 buttonTextStyle = MaterialTheme.typography.labelMedium
             )
         }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -207,7 +207,31 @@ data class ConciergeInputColors(
 
 data class ConciergeFeedbackColors(
     val iconButtonBackground: String? = null,
-    val iconButtonHoverBackground: String? = null
+    val iconButtonHoverBackground: String? = null,
+    /** Dialog sheet/modal background fill. Also applied to the notes editor. */
+    val sheetBackground: String? = null,
+    /** Dialog title text color. */
+    val titleText: String? = null,
+    /** Dialog question text color. */
+    val questionText: String? = null,
+    /** Checkbox option label color. */
+    val optionsText: String? = null,
+    /** Checkbox unchecked outline color; also reused for the notes editor outline. */
+    val checkboxBorder: String? = null,
+    /** Notes label and placeholder color. */
+    val notesText: String? = null,
+    /** Action sheet drag handle color. */
+    val dragHandle: String? = null,
+    /** Submit button fill color. */
+    val submitButtonFill: String? = null,
+    /** Submit button text color. */
+    val submitButtonText: String? = null,
+    /** Cancel button fill color. `null` renders with a transparent fill (outline style). Also tints the X close icon. */
+    val cancelButtonFill: String? = null,
+    /** Cancel button text color. */
+    val cancelButtonText: String? = null,
+    /** Cancel button border color. */
+    val cancelButtonBorder: String? = null
 )
 
 data class ConciergeCitationColors(

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -75,7 +75,17 @@ data class ConciergeLayout(
     
     // Feedback layout
     val feedbackContainerGap: Double? = null,
-    
+    val feedbackSubmitButtonBorderRadius: Double? = null,
+    val feedbackCancelButtonBorderRadius: Double? = null,
+    val feedbackCancelButtonBorderWidth: Double? = null,
+    val feedbackSubmitButtonFontWeight: Int? = null,
+    val feedbackCancelButtonFontWeight: Int? = null,
+    val feedbackCheckboxBorderRadius: Double? = null,
+    /** Title text alignment. `null` falls back to `START` (leading). */
+    val feedbackTitleTextAlign: ConciergeTextAlignment? = null,
+    /** Dialog title font size in points. `null` falls back to Material `titleMedium`. */
+    val feedbackTitleFontSize: Double? = null,
+
     // Citations layout
     val citationsTextFontWeight: Int? = null,
     val citationsDesktopButtonFontSize: Double? = null,
@@ -159,7 +169,11 @@ data class ConciergeComponentsConfig(
 )
 
 data class ConciergeFeedbackComponent(
-    val iconButtonSizeDesktop: Double? = null
+    val iconButtonSizeDesktop: Double? = null,
+    /** Whether the notes field is shown for positive feedback. Default `true`. */
+    val positiveNotesEnabled: Boolean = true,
+    /** Whether the notes field is shown for negative feedback. Default `true`. */
+    val negativeNotesEnabled: Boolean = true
 )
 
 /**
@@ -208,26 +222,30 @@ data class ConciergePromptSuggestionsBehavior(
  * Chat behavior configuration from `behavior.chat` in theme JSON.
  */
 data class ConciergeChatBehavior(
-    val messageAlignment: ChatMessageAlignment = ChatMessageAlignment.START,
+    val messageAlignment: ConciergeTextAlignment = ConciergeTextAlignment.START,
     val messageWidth: String? = null,
     val userMessageBubbleStyle: UserMessageBubbleStyle = UserMessageBubbleStyle.DEFAULT
 )
 
 /**
- * Horizontal alignment for chat messages from `behavior.chat.messageAlignment` in theme JSON.
- *
- * - `"start"` — messages align to the leading edge (default).
- * - `"center"` — messages are horizontally centered.
- * - `"end"` — messages align to the trailing edge.
+ * Horizontal text/content alignment with Compose-idiomatic case names (Start/End vs Leading/Trailing).
+ * Accepts (case-insensitive): `"left"` / `"leading"` / `"start"` -> START,
+ * `"center"` / `"justify"` -> CENTER, `"right"` / `"trailing"` / `"end"` -> END.
+ * Unknown or `null` falls back to `START`.
  */
-enum class ChatMessageAlignment(val value: String) {
+enum class ConciergeTextAlignment(val value: String) {
     START("start"),
     CENTER("center"),
     END("end");
 
     companion object {
-        fun fromString(value: String): ChatMessageAlignment =
-            values().firstOrNull { it.value.equals(value, ignoreCase = true) } ?: START
+        fun fromString(value: String?): ConciergeTextAlignment =
+            when (value?.trim()?.lowercase()) {
+                "left", "leading", "start" -> START
+                "right", "trailing", "end" -> END
+                "center", "justify" -> CENTER
+                else -> START
+            }
     }
 }
 
@@ -317,8 +335,23 @@ enum class CarouselStyle(val value: String) {
 
 data class ConciergeFeedbackBehavior(
     val displayMode: FeedbackDisplayMode = FeedbackDisplayMode.MODAL,
-    val thumbsPlacement: FeedbackThumbsPlacement = FeedbackThumbsPlacement.INLINE
-)
+    val thumbsPlacement: FeedbackThumbsPlacement = FeedbackThumbsPlacement.INLINE,
+    /** Overrides the close (X) button visibility. `null` defaults to `true` for `"action"`, `false` for `"modal"`. */
+    val showCloseButton: Boolean? = null,
+    /** Overrides the Cancel button visibility. `null` defaults to `true` for `"modal"`, `false` for `"action"`. */
+    val showCancelButton: Boolean? = null,
+    /** Overrides notes field visibility. `null` falls back to per-sentiment `positiveNotesEnabled` / `negativeNotesEnabled`. */
+    val showNotes: Boolean? = null
+) {
+    /** Effective close button visibility: `showCloseButton` when set, otherwise `displayMode == ACTION`. */
+    fun resolvedShowCloseButton(): Boolean = showCloseButton ?: (displayMode == FeedbackDisplayMode.ACTION)
+
+    /** Effective Cancel button visibility: `showCancelButton` when set, otherwise `displayMode == MODAL`. */
+    fun resolvedShowCancelButton(): Boolean = showCancelButton ?: (displayMode == FeedbackDisplayMode.MODAL)
+
+    /** Notes field visibility: `showNotes` when set, otherwise the provided per-sentiment fallback. */
+    fun resolvedShowNotes(fallback: Boolean): Boolean = showNotes ?: fallback
+}
 
 /**
  * Placement of the feedback thumbs relative to the sources accordion.

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -162,7 +162,8 @@ internal object ThemeParser {
             behavior = parseBehavior(json["behavior"] as? Map<*, *>),
             assets = parseAssets(json["assets"] as? Map<*, *>),
             content = parseContent(json["content"] as? Map<*, *>),
-            layout = parseLayout(json["layout"] as? Map<*, *>)
+            layout = parseLayout(json["layout"] as? Map<*, *>),
+            components = parseComponentsConfig(json["components"] as? Map<*, *>)
         )
         
         // Parse CSS variables from "theme" block
@@ -172,6 +173,23 @@ internal object ThemeParser {
         }
         
         return theme
+    }
+
+    /** Parses the `components` JSON block. Returns `null` when the block is absent. */
+    private fun parseComponentsConfig(map: Map<*, *>?): ConciergeComponentsConfig? {
+        if (map == null) return null
+        val feedbackMap = map["feedback"] as? Map<*, *>
+        val feedbackComponent = feedbackMap?.let {
+            @Suppress("UNCHECKED_CAST")
+            val typed = it as? MutableMap<String?, Any?>
+            ConciergeFeedbackComponent(
+                iconButtonSizeDesktop = DataReader.optDouble(typed, "iconButtonSizeDesktop", 0.0)
+                    .takeIf { value -> value > 0.0 },
+                positiveNotesEnabled = DataReader.optBoolean(typed, "positiveNotesEnabled", true),
+                negativeNotesEnabled = DataReader.optBoolean(typed, "negativeNotesEnabled", true)
+            )
+        }
+        return ConciergeComponentsConfig(feedback = feedbackComponent)
     }
     
     /**
@@ -331,6 +349,19 @@ internal object ThemeParser {
             // Feedback-specific colors from CSS themes
             feedbackIconButtonBackground = themeColors.feedback?.iconButtonBackground?.toComposeColor(),
             feedbackIconButtonHoverBackground = themeColors.feedback?.iconButtonHoverBackground?.toComposeColor(),
+            // Feedback dialog extended styling from CSS themes
+            feedbackSheetBackground = themeColors.feedback?.sheetBackground?.toComposeColor(),
+            feedbackTitleText = themeColors.feedback?.titleText?.toComposeColor(),
+            feedbackQuestionText = themeColors.feedback?.questionText?.toComposeColor(),
+            feedbackOptionsText = themeColors.feedback?.optionsText?.toComposeColor(),
+            feedbackCheckboxBorder = themeColors.feedback?.checkboxBorder?.toComposeColor(),
+            feedbackNotesText = themeColors.feedback?.notesText?.toComposeColor(),
+            feedbackDragHandle = themeColors.feedback?.dragHandle?.toComposeColor(),
+            feedbackSubmitButtonFill = themeColors.feedback?.submitButtonFill?.toComposeColor(),
+            feedbackSubmitButtonText = themeColors.feedback?.submitButtonText?.toComposeColor(),
+            feedbackCancelButtonFill = themeColors.feedback?.cancelButtonFill?.toComposeColor(),
+            feedbackCancelButtonText = themeColors.feedback?.cancelButtonText?.toComposeColor(),
+            feedbackCancelButtonBorder = themeColors.feedback?.cancelButtonBorder?.toComposeColor(),
             // Prompt pill colors from CSS themes
             welcomePromptBackground = themeColors.welcomePrompt?.backgroundColor?.toComposeColor(),
             welcomePromptText = themeColors.welcomePrompt?.textColor?.toComposeColor(),
@@ -411,7 +442,10 @@ internal object ThemeParser {
         val feedback = feedbackTyped?.let {
             ConciergeFeedbackBehavior(
                 displayMode = FeedbackDisplayMode.fromString(DataReader.optString(it, "displayMode", "modal")),
-                thumbsPlacement = FeedbackThumbsPlacement.fromString(DataReader.optString(it, "thumbsPlacement", "inline"))
+                thumbsPlacement = FeedbackThumbsPlacement.fromString(DataReader.optString(it, "thumbsPlacement", "inline")),
+                showCloseButton = it["showCloseButton"] as? Boolean,
+                showCancelButton = it["showCancelButton"] as? Boolean,
+                showNotes = it["showNotes"] as? Boolean
             )
         }
 
@@ -441,7 +475,7 @@ internal object ThemeParser {
         val chatTyped = chatMap as? MutableMap<String?, Any?>
         val chat = chatTyped?.let {
             ConciergeChatBehavior(
-                messageAlignment = ChatMessageAlignment.fromString(DataReader.optString(it, "messageAlignment", "start") ?: "start"),
+                messageAlignment = ConciergeTextAlignment.fromString(DataReader.optString(it, "messageAlignment", "start") ?: "start"),
                 messageWidth = DataReader.optString(it, "messageWidth", null),
                 userMessageBubbleStyle = UserMessageBubbleStyle.fromString(DataReader.optString(it, "userMessageBubbleStyle", "default"))
             )

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
@@ -55,6 +55,44 @@ class CSSKeyMapperTest {
         assertTrue(keys.contains("feedback-icon-btn-size-desktop"))
     }
 
+    @Test
+    fun `supportedCSSKeys registers all 12 feedback dialog color keys`() {
+        val keys = CSSKeyMapper.supportedCSSKeys
+        val feedbackColorKeys = setOf(
+            "feedback-sheet-background-color",
+            "feedback-title-text-color",
+            "feedback-question-text-color",
+            "feedback-options-text-color",
+            "feedback-checkbox-border-color",
+            "feedback-notes-text-color",
+            "feedback-drag-handle-color",
+            "feedback-submit-button-fill-color",
+            "feedback-submit-button-text-color",
+            "feedback-cancel-button-fill-color",
+            "feedback-cancel-button-text-color",
+            "feedback-cancel-button-border-color"
+        )
+        val missing = feedbackColorKeys - keys
+        assertTrue("CSSKeyMapper is missing feedback color keys: ${missing.sorted().joinToString()}", missing.isEmpty())
+    }
+
+    @Test
+    fun `supportedCSSKeys registers all 8 feedback dialog layout keys`() {
+        val keys = CSSKeyMapper.supportedCSSKeys
+        val feedbackLayoutKeys = setOf(
+            "feedback-submit-button-border-radius",
+            "feedback-cancel-button-border-radius",
+            "feedback-cancel-button-border-width",
+            "feedback-submit-button-font-weight",
+            "feedback-cancel-button-font-weight",
+            "feedback-checkbox-border-radius",
+            "feedback-title-text-align",
+            "feedback-title-font-size"
+        )
+        val missing = feedbackLayoutKeys - keys
+        assertTrue("CSSKeyMapper is missing feedback layout keys: ${missing.sorted().joinToString()}", missing.isEmpty())
+    }
+
     // -----------------------------------------------------------------------
     // Typography
     // -----------------------------------------------------------------------
@@ -1046,5 +1084,193 @@ class CSSKeyMapperTest {
         assertTrue(keys.contains("thinking-bubble-padding-horizontal"))
         assertTrue(keys.contains("thinking-bubble-padding-vertical"))
         assertTrue(keys.contains("thinking-dot-vertical-alignment"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Feedback dialog colors (12 new CSS vars)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `apply maps feedback-sheet-background-color`() {
+        val result = CSSKeyMapper.apply("--feedback-sheet-background-color", "#FFFFFF", emptyTheme)
+        assertEquals("#FFFFFF", result.colors?.feedback?.sheetBackground)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-color", "#131313", emptyTheme)
+        assertEquals("#131313", result.colors?.feedback?.titleText)
+    }
+
+    @Test
+    fun `apply maps feedback-question-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-question-text-color", "#424242", emptyTheme)
+        assertEquals("#424242", result.colors?.feedback?.questionText)
+    }
+
+    @Test
+    fun `apply maps feedback-options-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-options-text-color", "#131313", emptyTheme)
+        assertEquals("#131313", result.colors?.feedback?.optionsText)
+    }
+
+    @Test
+    fun `apply maps feedback-checkbox-border-color`() {
+        val result = CSSKeyMapper.apply("--feedback-checkbox-border-color", "#131313", emptyTheme)
+        assertEquals("#131313", result.colors?.feedback?.checkboxBorder)
+    }
+
+    @Test
+    fun `apply maps feedback-notes-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-notes-text-color", "#131313", emptyTheme)
+        assertEquals("#131313", result.colors?.feedback?.notesText)
+    }
+
+    @Test
+    fun `apply maps feedback-drag-handle-color`() {
+        val result = CSSKeyMapper.apply("--feedback-drag-handle-color", "#CCCCCC", emptyTheme)
+        assertEquals("#CCCCCC", result.colors?.feedback?.dragHandle)
+    }
+
+    @Test
+    fun `apply maps feedback-submit-button-fill-color`() {
+        val result = CSSKeyMapper.apply("--feedback-submit-button-fill-color", "#3B63FB", emptyTheme)
+        assertEquals("#3B63FB", result.colors?.feedback?.submitButtonFill)
+    }
+
+    @Test
+    fun `apply maps feedback-submit-button-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-submit-button-text-color", "#FFFFFF", emptyTheme)
+        assertEquals("#FFFFFF", result.colors?.feedback?.submitButtonText)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-fill-color`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-fill-color", "#FFFFFF", emptyTheme)
+        assertEquals("#FFFFFF", result.colors?.feedback?.cancelButtonFill)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-text-color`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-text-color", "#2C2C2C", emptyTheme)
+        assertEquals("#2C2C2C", result.colors?.feedback?.cancelButtonText)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-border-color`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-border-color", "#2C2C2C", emptyTheme)
+        assertEquals("#2C2C2C", result.colors?.feedback?.cancelButtonBorder)
+    }
+
+    // -----------------------------------------------------------------------
+    // Feedback dialog layout (8 new CSS vars)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `apply maps feedback-submit-button-border-radius`() {
+        val result = CSSKeyMapper.apply("--feedback-submit-button-border-radius", "10px", emptyTheme)
+        assertEquals(10.0, result.cssLayout?.feedbackSubmitButtonBorderRadius)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-border-radius`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-border-radius", "10px", emptyTheme)
+        assertEquals(10.0, result.cssLayout?.feedbackCancelButtonBorderRadius)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-border-width`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-border-width", "1px", emptyTheme)
+        assertEquals(1.0, result.cssLayout?.feedbackCancelButtonBorderWidth)
+    }
+
+    @Test
+    fun `apply maps feedback-submit-button-font-weight`() {
+        val result = CSSKeyMapper.apply("--feedback-submit-button-font-weight", "600", emptyTheme)
+        assertEquals(600, result.cssLayout?.feedbackSubmitButtonFontWeight)
+    }
+
+    @Test
+    fun `apply maps feedback-cancel-button-font-weight`() {
+        val result = CSSKeyMapper.apply("--feedback-cancel-button-font-weight", "600", emptyTheme)
+        assertEquals(600, result.cssLayout?.feedbackCancelButtonFontWeight)
+    }
+
+    @Test
+    fun `apply maps feedback-checkbox-border-radius`() {
+        val result = CSSKeyMapper.apply("--feedback-checkbox-border-radius", "6px", emptyTheme)
+        assertEquals(6.0, result.cssLayout?.feedbackCheckboxBorderRadius)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align leading to START`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "leading", emptyTheme)
+        assertEquals(ConciergeTextAlignment.START, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align center`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "center", emptyTheme)
+        assertEquals(ConciergeTextAlignment.CENTER, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align left to START`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "left", emptyTheme)
+        assertEquals(ConciergeTextAlignment.START, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align right to END`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "right", emptyTheme)
+        assertEquals(ConciergeTextAlignment.END, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align justify to CENTER`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "justify", emptyTheme)
+        assertEquals(ConciergeTextAlignment.CENTER, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-text-align unknown value to START`() {
+        val result = CSSKeyMapper.apply("--feedback-title-text-align", "bogus", emptyTheme)
+        assertEquals(ConciergeTextAlignment.START, result.cssLayout?.feedbackTitleTextAlign)
+    }
+
+    @Test
+    fun `apply maps feedback-title-font-size`() {
+        val result = CSSKeyMapper.apply("--feedback-title-font-size", "22px", emptyTheme)
+        assertEquals(22.0, result.cssLayout?.feedbackTitleFontSize)
+    }
+
+    @Test
+    fun `supportedCSSKeys contains all new feedback dialog keys`() {
+        val keys = CSSKeyMapper.supportedCSSKeys
+        val expected = listOf(
+            "feedback-sheet-background-color",
+            "feedback-title-text-color",
+            "feedback-question-text-color",
+            "feedback-options-text-color",
+            "feedback-checkbox-border-color",
+            "feedback-notes-text-color",
+            "feedback-drag-handle-color",
+            "feedback-submit-button-fill-color",
+            "feedback-submit-button-text-color",
+            "feedback-cancel-button-fill-color",
+            "feedback-cancel-button-text-color",
+            "feedback-cancel-button-border-color",
+            "feedback-submit-button-border-radius",
+            "feedback-cancel-button-border-radius",
+            "feedback-cancel-button-border-width",
+            "feedback-submit-button-font-weight",
+            "feedback-cancel-button-font-weight",
+            "feedback-checkbox-border-radius",
+            "feedback-title-text-align",
+            "feedback-title-font-size"
+        )
+        expected.forEach { key ->
+            assertTrue("supportedCSSKeys should contain $key", keys.contains(key))
+        }
     }
 }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeFeedbackBehaviorTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeFeedbackBehaviorTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.concierge.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests visibility defaults and overrides for the feedback close (X) and Cancel buttons,
+ * and for the notes field. Mirrors the iOS `ConciergeFeedbackBehaviorTests` coverage.
+ */
+class ConciergeFeedbackBehaviorTest {
+
+    // ========== Default resolution by displayMode ==========
+
+    @Test
+    fun `defaults modal close hidden cancel shown`() {
+        val behavior = ConciergeFeedbackBehavior(displayMode = FeedbackDisplayMode.MODAL)
+
+        assertFalse(behavior.resolvedShowCloseButton())
+        assertTrue(behavior.resolvedShowCancelButton())
+    }
+
+    @Test
+    fun `defaults action close shown cancel hidden`() {
+        val behavior = ConciergeFeedbackBehavior(displayMode = FeedbackDisplayMode.ACTION)
+
+        assertTrue(behavior.resolvedShowCloseButton())
+        assertFalse(behavior.resolvedShowCancelButton())
+    }
+
+    // ========== Explicit overrides ==========
+
+    @Test
+    fun `explicit overrides modal close true cancel false honored`() {
+        val behavior = ConciergeFeedbackBehavior(
+            displayMode = FeedbackDisplayMode.MODAL,
+            showCloseButton = true,
+            showCancelButton = false
+        )
+
+        assertTrue(behavior.resolvedShowCloseButton())
+        assertFalse(behavior.resolvedShowCancelButton())
+    }
+
+    @Test
+    fun `explicit overrides action close false cancel true honored`() {
+        val behavior = ConciergeFeedbackBehavior(
+            displayMode = FeedbackDisplayMode.ACTION,
+            showCloseButton = false,
+            showCancelButton = true
+        )
+
+        assertFalse(behavior.resolvedShowCloseButton())
+        assertTrue(behavior.resolvedShowCancelButton())
+    }
+
+    /**
+     * Both `false` is respected -- neither button is shown. Submit always exits;
+     * action mode also allows drag-down.
+     */
+    @Test
+    fun `explicit overrides both false honored without auto flipping`() {
+        for (displayMode in listOf(FeedbackDisplayMode.MODAL, FeedbackDisplayMode.ACTION)) {
+            val behavior = ConciergeFeedbackBehavior(
+                displayMode = displayMode,
+                showCloseButton = false,
+                showCancelButton = false
+            )
+
+            assertFalse(
+                "displayMode=$displayMode should honor showCloseButton=false without auto-flipping",
+                behavior.resolvedShowCloseButton()
+            )
+            assertFalse(
+                "displayMode=$displayMode should honor showCancelButton=false without auto-flipping",
+                behavior.resolvedShowCancelButton()
+            )
+        }
+    }
+
+    @Test
+    fun `default nullable overrides remain null`() {
+        val behavior = ConciergeFeedbackBehavior()
+
+        assertNull(behavior.showCloseButton)
+        assertNull(behavior.showCancelButton)
+        assertNull(behavior.showNotes)
+    }
+
+    // ========== showNotes resolver ==========
+
+    /** When `showNotes` is null, fall back to the per-sentiment value. */
+    @Test
+    fun `resolvedShowNotes null falls back to per sentiment fallback`() {
+        val behavior = ConciergeFeedbackBehavior(showNotes = null)
+
+        assertTrue(behavior.resolvedShowNotes(fallback = true))
+        assertFalse(behavior.resolvedShowNotes(fallback = false))
+    }
+
+    @Test
+    fun `resolvedShowNotes explicit true overrides fallback`() {
+        val behavior = ConciergeFeedbackBehavior(showNotes = true)
+
+        assertTrue(behavior.resolvedShowNotes(fallback = false))
+        assertTrue(behavior.resolvedShowNotes(fallback = true))
+    }
+
+    @Test
+    fun `resolvedShowNotes explicit false overrides fallback`() {
+        val behavior = ConciergeFeedbackBehavior(showNotes = false)
+
+        assertFalse(behavior.resolvedShowNotes(fallback = true))
+        assertFalse(behavior.resolvedShowNotes(fallback = false))
+    }
+
+    // ========== ConciergeFeedbackComponent per-sentiment flags ==========
+
+    @Test
+    fun `ConciergeFeedbackComponent defaults both sentiments to enabled`() {
+        val component = ConciergeFeedbackComponent()
+
+        assertTrue(component.positiveNotesEnabled)
+        assertTrue(component.negativeNotesEnabled)
+    }
+
+    @Test
+    fun `ConciergeFeedbackComponent supports disabling per sentiment`() {
+        val positiveOnly = ConciergeFeedbackComponent(
+            positiveNotesEnabled = true,
+            negativeNotesEnabled = false
+        )
+        val negativeOnly = ConciergeFeedbackComponent(
+            positiveNotesEnabled = false,
+            negativeNotesEnabled = true
+        )
+
+        assertTrue(positiveOnly.positiveNotesEnabled)
+        assertFalse(positiveOnly.negativeNotesEnabled)
+        assertFalse(negativeOnly.positiveNotesEnabled)
+        assertTrue(negativeOnly.negativeNotesEnabled)
+    }
+
+    @Test
+    fun `copy preserves feedback behavior overrides`() {
+        val original = ConciergeFeedbackBehavior(
+            displayMode = FeedbackDisplayMode.ACTION,
+            showCloseButton = false,
+            showCancelButton = true,
+            showNotes = false
+        )
+        val updated = original.copy(displayMode = FeedbackDisplayMode.MODAL)
+
+        assertEquals(FeedbackDisplayMode.MODAL, updated.displayMode)
+        assertFalse(updated.showCloseButton!!)
+        assertTrue(updated.showCancelButton!!)
+        assertFalse(updated.showNotes!!)
+    }
+}

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokensTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokensTest.kt
@@ -318,32 +318,55 @@ class ConciergeThemeTokensTest {
         assertEquals(UserMessageBubbleStyle.DEFAULT, UserMessageBubbleStyle.fromString("unknown"))
     }
 
-    // ========== ChatMessageAlignment Tests ==========
+    // ========== ConciergeTextAlignment Tests ==========
 
     @Test
-    fun `ChatMessageAlignment fromString returns START for start`() {
-        assertEquals(ChatMessageAlignment.START, ChatMessageAlignment.fromString("start"))
+    fun `ConciergeTextAlignment fromString returns START for start`() {
+        assertEquals(ConciergeTextAlignment.START, ConciergeTextAlignment.fromString("start"))
     }
 
     @Test
-    fun `ChatMessageAlignment fromString returns CENTER for center`() {
-        assertEquals(ChatMessageAlignment.CENTER, ChatMessageAlignment.fromString("center"))
+    fun `ConciergeTextAlignment fromString returns CENTER for center`() {
+        assertEquals(ConciergeTextAlignment.CENTER, ConciergeTextAlignment.fromString("center"))
     }
 
     @Test
-    fun `ChatMessageAlignment fromString returns END for end`() {
-        assertEquals(ChatMessageAlignment.END, ChatMessageAlignment.fromString("end"))
+    fun `ConciergeTextAlignment fromString returns END for end`() {
+        assertEquals(ConciergeTextAlignment.END, ConciergeTextAlignment.fromString("end"))
     }
 
     @Test
-    fun `ChatMessageAlignment fromString is case insensitive`() {
-        assertEquals(ChatMessageAlignment.CENTER, ChatMessageAlignment.fromString("CENTER"))
-        assertEquals(ChatMessageAlignment.END, ChatMessageAlignment.fromString("End"))
+    fun `ConciergeTextAlignment fromString is case insensitive`() {
+        assertEquals(ConciergeTextAlignment.CENTER, ConciergeTextAlignment.fromString("CENTER"))
+        assertEquals(ConciergeTextAlignment.END, ConciergeTextAlignment.fromString("End"))
     }
 
     @Test
-    fun `ChatMessageAlignment fromString returns START for unknown value`() {
-        assertEquals(ChatMessageAlignment.START, ChatMessageAlignment.fromString("unknown"))
+    fun `ConciergeTextAlignment fromString maps web CSS values`() {
+        assertEquals(ConciergeTextAlignment.START, ConciergeTextAlignment.fromString("left"))
+        assertEquals(ConciergeTextAlignment.END, ConciergeTextAlignment.fromString("right"))
+        assertEquals(ConciergeTextAlignment.CENTER, ConciergeTextAlignment.fromString("justify"))
+    }
+
+    @Test
+    fun `ConciergeTextAlignment fromString maps iOS idioms`() {
+        assertEquals(ConciergeTextAlignment.START, ConciergeTextAlignment.fromString("leading"))
+        assertEquals(ConciergeTextAlignment.END, ConciergeTextAlignment.fromString("trailing"))
+    }
+
+    @Test
+    fun `ConciergeTextAlignment fromString trims whitespace`() {
+        assertEquals(ConciergeTextAlignment.CENTER, ConciergeTextAlignment.fromString("  center  "))
+    }
+
+    @Test
+    fun `ConciergeTextAlignment fromString returns START for null`() {
+        assertEquals(ConciergeTextAlignment.START, ConciergeTextAlignment.fromString(null))
+    }
+
+    @Test
+    fun `ConciergeTextAlignment fromString returns START for unknown value`() {
+        assertEquals(ConciergeTextAlignment.START, ConciergeTextAlignment.fromString("unknown"))
     }
 
     // ========== ConciergeChatBehavior Tests ==========
@@ -352,7 +375,7 @@ class ConciergeThemeTokensTest {
     fun `ConciergeChatBehavior creates with defaults`() {
         val chat = ConciergeChatBehavior()
 
-        assertEquals(ChatMessageAlignment.START, chat.messageAlignment)
+        assertEquals(ConciergeTextAlignment.START, chat.messageAlignment)
         assertNull(chat.messageWidth)
         assertEquals(UserMessageBubbleStyle.DEFAULT, chat.userMessageBubbleStyle)
     }
@@ -360,12 +383,12 @@ class ConciergeThemeTokensTest {
     @Test
     fun `ConciergeChatBehavior creates with custom values`() {
         val chat = ConciergeChatBehavior(
-            messageAlignment = ChatMessageAlignment.CENTER,
+            messageAlignment = ConciergeTextAlignment.CENTER,
             messageWidth = "100%",
             userMessageBubbleStyle = UserMessageBubbleStyle.BALLOON
         )
 
-        assertEquals(ChatMessageAlignment.CENTER, chat.messageAlignment)
+        assertEquals(ConciergeTextAlignment.CENTER, chat.messageAlignment)
         assertEquals("100%", chat.messageWidth)
         assertEquals(UserMessageBubbleStyle.BALLOON, chat.userMessageBubbleStyle)
     }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
@@ -673,6 +673,162 @@ class ThemeParserTest {
     }
 
     @Test
+    fun `parseThemeTokens parses feedback behavior showCloseButton showCancelButton showNotes`() {
+        val json = """
+            {
+                "behavior": {
+                    "feedback": {
+                        "displayMode": "action",
+                        "showCloseButton": false,
+                        "showCancelButton": true,
+                        "showNotes": false
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val feedback = tokens?.behavior?.feedback
+
+        assertNotNull(feedback)
+        assertEquals(FeedbackDisplayMode.ACTION, feedback?.displayMode)
+        assertEquals(false, feedback?.showCloseButton)
+        assertEquals(true, feedback?.showCancelButton)
+        assertEquals(false, feedback?.showNotes)
+    }
+
+    @Test
+    fun `parseThemeTokens leaves feedback behavior overrides null when keys are missing`() {
+        val json = """
+            {
+                "behavior": {
+                    "feedback": {
+                        "displayMode": "modal"
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val feedback = tokens?.behavior?.feedback
+
+        assertNotNull(feedback)
+        assertNull(feedback?.showCloseButton)
+        assertNull(feedback?.showCancelButton)
+        assertNull(feedback?.showNotes)
+    }
+
+    @Test
+    fun `parseThemeTokens parses components feedback positiveNotesEnabled and negativeNotesEnabled`() {
+        val json = """
+            {
+                "components": {
+                    "feedback": {
+                        "iconButtonSizeDesktop": 36,
+                        "positiveNotesEnabled": false,
+                        "negativeNotesEnabled": true
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val component = tokens?.components?.feedback
+
+        assertNotNull(component)
+        assertEquals(36.0, component?.iconButtonSizeDesktop)
+        assertEquals(false, component?.positiveNotesEnabled)
+        assertEquals(true, component?.negativeNotesEnabled)
+    }
+
+    @Test
+    fun `parseThemeTokens defaults components feedback notesEnabled flags to true when missing`() {
+        val json = """
+            {
+                "components": {
+                    "feedback": {}
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val component = tokens?.components?.feedback
+
+        assertNotNull(component)
+        assertEquals(true, component?.positiveNotesEnabled)
+        assertEquals(true, component?.negativeNotesEnabled)
+    }
+
+    @Test
+    fun `parseThemeTokens wires new feedback colors from theme CSS vars`() {
+        val json = """
+            {
+                "theme": {
+                    "--feedback-sheet-background-color": "#FFFFFF",
+                    "--feedback-title-text-color": "#131313",
+                    "--feedback-question-text-color": "#424242",
+                    "--feedback-options-text-color": "#222222",
+                    "--feedback-checkbox-border-color": "#131313",
+                    "--feedback-notes-text-color": "#131313",
+                    "--feedback-drag-handle-color": "#CCCCCC",
+                    "--feedback-submit-button-fill-color": "#3B63FB",
+                    "--feedback-submit-button-text-color": "#FFFFFF",
+                    "--feedback-cancel-button-fill-color": "#FFFFFF",
+                    "--feedback-cancel-button-text-color": "#2C2C2C",
+                    "--feedback-cancel-button-border-color": "#2C2C2C"
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val feedback = tokens?.colors?.feedback
+
+        assertNotNull(feedback)
+        assertEquals("#FFFFFF", feedback?.sheetBackground)
+        assertEquals("#131313", feedback?.titleText)
+        assertEquals("#424242", feedback?.questionText)
+        assertEquals("#222222", feedback?.optionsText)
+        assertEquals("#131313", feedback?.checkboxBorder)
+        assertEquals("#131313", feedback?.notesText)
+        assertEquals("#CCCCCC", feedback?.dragHandle)
+        assertEquals("#3B63FB", feedback?.submitButtonFill)
+        assertEquals("#FFFFFF", feedback?.submitButtonText)
+        assertEquals("#FFFFFF", feedback?.cancelButtonFill)
+        assertEquals("#2C2C2C", feedback?.cancelButtonText)
+        assertEquals("#2C2C2C", feedback?.cancelButtonBorder)
+    }
+
+    @Test
+    fun `parseThemeTokens parses new feedback layout CSS vars`() {
+        val json = """
+            {
+                "theme": {
+                    "--feedback-submit-button-border-radius": "10px",
+                    "--feedback-cancel-button-border-radius": "10px",
+                    "--feedback-cancel-button-border-width": "1px",
+                    "--feedback-submit-button-font-weight": "600",
+                    "--feedback-cancel-button-font-weight": "500",
+                    "--feedback-checkbox-border-radius": "6px",
+                    "--feedback-title-text-align": "leading",
+                    "--feedback-title-font-size": "22px"
+                }
+            }
+        """.trimIndent()
+
+        val tokens = ThemeParser.parseThemeTokens(json)
+        val layout = tokens?.cssLayout
+
+        assertEquals(10.0, layout?.feedbackSubmitButtonBorderRadius)
+        assertEquals(10.0, layout?.feedbackCancelButtonBorderRadius)
+        assertEquals(1.0, layout?.feedbackCancelButtonBorderWidth)
+        assertEquals(600, layout?.feedbackSubmitButtonFontWeight)
+        assertEquals(500, layout?.feedbackCancelButtonFontWeight)
+        assertEquals(6.0, layout?.feedbackCheckboxBorderRadius)
+        assertEquals(ConciergeTextAlignment.START, layout?.feedbackTitleTextAlign)
+        assertEquals(22.0, layout?.feedbackTitleFontSize)
+    }
+
+    @Test
     fun `parseThemeTokens should parse behavior feedback displayMode`() {
         val modalJson = """
             {
@@ -715,7 +871,7 @@ class ThemeParserTest {
         val tokens = ThemeParser.parseThemeTokens(json)
 
         assertNotNull(tokens?.behavior?.chat)
-        assertEquals(ChatMessageAlignment.CENTER, tokens?.behavior?.chat?.messageAlignment)
+        assertEquals(ConciergeTextAlignment.CENTER, tokens?.behavior?.chat?.messageAlignment)
         assertEquals("100%", tokens?.behavior?.chat?.messageWidth)
         assertEquals(UserMessageBubbleStyle.BALLOON, tokens?.behavior?.chat?.userMessageBubbleStyle)
     }

--- a/code/testapp/src/main/assets/themeDefault.json
+++ b/code/testapp/src/main/assets/themeDefault.json
@@ -28,13 +28,22 @@
     },
     "feedback": {
       "displayMode": "modal",
-      "thumbsPlacement": "inline"
+      "thumbsPlacement": "inline",
+      "showCloseButton": null,
+      "showCancelButton": null,
+      "showNotes": null
     },
     "citations": {
       "showLinkIcon": false
     },
     "welcomeCard": {
       "contentAlignment": "center"
+    }
+  },
+  "components": {
+    "feedback": {
+      "positiveNotesEnabled": true,
+      "negativeNotesEnabled": true
     }
   },
   "disclaimer": {
@@ -69,7 +78,7 @@
     "feedback.dialog.question.positive": "What went well? Select all that apply.",
     "feedback.dialog.question.negative": "What went wrong? Select all that apply.",
     "feedback.dialog.notes": "Notes",
-    "feedback.dialog.submit": "Submit",
+    "feedback.dialog.submit": "SUBMIT",
     "feedback.dialog.cancel": "Cancel",
     "feedback.dialog.notes.placeholder": "Additional notes (optional)",
     "feedback.toast.success": "Thank you for the feedback.",
@@ -172,6 +181,26 @@
     "--feedback-icon-btn-hover-background": "#FFFFFF",
     "--feedback-icon-btn-size-desktop": "32px",
     "--feedback-container-gap": "4px",
+    "--feedback-sheet-background-color": "#FFFFFF",
+    "--feedback-title-text-color": "#131313",
+    "--feedback-question-text-color": "#424242",
+    "--feedback-options-text-color": "#131313",
+    "--feedback-checkbox-border-color": "#131313",
+    "--feedback-notes-text-color": "#131313",
+    "--feedback-drag-handle-color": "#CCCCCC",
+    "--feedback-submit-button-fill-color": "#C55C19",
+    "--feedback-submit-button-text-color": "#FFFFFF",
+    "--feedback-submit-button-border-radius": "4px",
+    "--feedback-submit-button-font-weight": "700",
+    "--feedback-cancel-button-fill-color": "#FFFFFF",
+    "--feedback-cancel-button-text-color": "#2C2C2C",
+    "--feedback-cancel-button-border-color": "#2C2C2C",
+    "--feedback-cancel-button-border-width": "1px",
+    "--feedback-cancel-button-border-radius": "10px",
+    "--feedback-cancel-button-font-weight": "600",
+    "--feedback-checkbox-border-radius": "0px",
+    "--feedback-title-text-align": "center",
+    "--feedback-title-font-size": "18px",
     "--multimodal-card-box-shadow": "none",
     "--border-radius-card": "16px",
     "--button-height-s": "30px",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a comprehensive set of theme tokens for styling the feedback dialog, three new
behavior flags for controlling dismiss affordance and notes field visibility, and refactors
the dialog composables to consume them.
### Theming
New CSS variables and model properties for:
- Dialog background: `--feedback-sheet-background-color` (also drives the notes editor fill)
- Text colors: `--feedback-title-text-color`, `--feedback-question-text-color`, `--feedback-options-text-color`, `--feedback-notes-text-color`, `--feedback-drag-handle-color`
- Checkbox: `--feedback-checkbox-border-color` (also reused for the notes editor outline)
- Submit + Cancel buttons: fill, text, border color, corner radius, font weight, border width
- Title: `--feedback-title-text-align`, `--feedback-title-font-size`
`FeedbackDialogStyle` gains the corresponding computed fields. Cancel defaults to
`Color.Transparent` (outline style) when `cancelButtonFill` is unset. The X close icon
tint resolves from `cancelButtonFill` with a `button.secondaryText` fallback.
### Behavior
- `showCloseButton`: X close button visibility. `null` = shown for `"action"`, hidden for `"modal"`.
- `showCancelButton`: Cancel button visibility. `null` = shown for `"modal"`, hidden for `"action"`. Both `false` is honored.
- `showNotes`: notes field visibility override for modal mode. `null` falls back to per-sentiment `components.feedback.positiveNotesEnabled` / `negativeNotesEnabled`.
- `ConciergeTextAlignment` replaces the old `ChatMessageAlignment` enum, extended to accept `"leading"` / `"trailing"` / `"justify"` aliases and a `null` input.
### Dialog refactor
Extracted shared composables (`FeedbackTitleRow`, `FeedbackActionButtons`, `FeedbackDragHandle`)
used by both card and bottom sheet modes. Cancel button is now `OutlinedButton` (was `TextButton`).
The drag handle is now themable instead of using Material3's default. Notes section is gated
by the resolved visibility flags rather than always rendered.
### Tests
- `ConciergeFeedbackBehaviorTest`: flag resolution and Codable round-trip
- `CSSKeyMapperTest`: coverage for all 12 new color keys and 8 new layout keys
- `ConciergeThemeTokensTest`, `ThemeParserTest`: expanded for new tokens and behavior parsing

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
