### PR TITLE
Remove show notes and text color controls

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -282,7 +282,6 @@ Feature toggles and interaction configuration.
 | `behavior.feedback.thumbsPlacement` | string | `"inline"` | Thumbs up/down placement. `"inline"` places thumbs beside the sources label; `"below"` places them below the sources accordion with an optional label. |
 | `behavior.feedback.showCloseButton` | boolean \| null | `null` | X close button visibility. `null` = shown for `"action"`, hidden for `"modal"`. |
 | `behavior.feedback.showCancelButton` | boolean \| null | `null` | Cancel button visibility. `null` = shown for `"modal"`, hidden for `"action"`. Both set to `false` is honored: Submit and (in action mode) drag-down still dismiss. |
-| `behavior.feedback.showNotes` | boolean \| null | `null` | Notes field visibility override for modal mode. `null` falls back to per-sentiment `positiveNotesEnabled` / `negativeNotesEnabled`. Not rendered in action mode. |
 
 ### Citations
 
@@ -340,8 +339,7 @@ Feature toggles and interaction configuration.
       "displayMode": "action",
       "thumbsPlacement": "below",
       "showCloseButton": true,
-      "showCancelButton": false,
-      "showNotes": null
+      "showCancelButton": false
     },
     "citations": {
       "showLinkIcon": true
@@ -698,7 +696,6 @@ These tokens style the feedback dialog (modal card and action bottom sheet).
 | `--feedback-question-text-color` | `colors.feedback.questionText` | `String?` | falls back to the title color | Dialog question color. |
 | `--feedback-options-text-color` | `colors.feedback.optionsText` | `String?` | falls back to the title color | Checkbox option label color. |
 | `--feedback-checkbox-border-color` | `colors.feedback.checkboxBorder` | `String?` | `"#7F7F7F"` (light) / `"#B0B0B0"` (dark) | Checkbox unchecked outline color. Also used for the notes editor outline. |
-| `--feedback-notes-text-color` | `colors.feedback.notesText` | `String?` | falls back to the title color | Notes label, entered text, and placeholder color. |
 | `--feedback-drag-handle-color` | `colors.feedback.dragHandle` | `String?` | `"#CCCCCC"` | Drag handle color. Only visible in action mode. |
 | `--feedback-submit-button-fill-color` | `colors.feedback.submitButtonFill` | `String?` | falls back to `colors.button.primaryBackground` | Submit button fill color. |
 | `--feedback-submit-button-text-color` | `colors.feedback.submitButtonText` | `String?` | falls back to `colors.button.primaryText` | Submit button text color. |
@@ -706,7 +703,7 @@ These tokens style the feedback dialog (modal card and action bottom sheet).
 | `--feedback-cancel-button-text-color` | `colors.feedback.cancelButtonText` | `String?` | falls back to `colors.button.secondaryText` | Cancel button label color. |
 | `--feedback-cancel-button-border-color` | `colors.feedback.cancelButtonBorder` | `String?` | falls back to `colors.button.secondaryBorder` | Cancel button outline color. |
 
-> **Contrast note:** When `--feedback-sheet-background-color` is pinned, also set `--feedback-title-text-color`, `--feedback-question-text-color`, `--feedback-options-text-color`, and `--feedback-notes-text-color` to maintain text contrast. System defaults track the device palette, not the themed surface.
+> **Contrast note:** When `--feedback-sheet-background-color` is pinned, also set `--feedback-title-text-color`, `--feedback-question-text-color`, and `--feedback-options-text-color` to maintain text contrast. System defaults track the device palette, not the themed surface.
 
 ### Colors - Disclaimer
 
@@ -846,8 +843,8 @@ Non-CSS `components.feedback` overrides for the feedback dialog.
 | JSON Key | Type | Default | Description |
 |----------|------|---------|-------------|
 | `components.feedback.iconButtonSizeDesktop` | number | `32` | Feedback icon button hit target size (dp). Mirrors `--feedback-icon-btn-size-desktop`. |
-| `components.feedback.positiveNotesEnabled` | boolean | `true` | Notes field visibility for positive-sentiment modal. Overridden by `behavior.feedback.showNotes`. Not applied in action mode. |
-| `components.feedback.negativeNotesEnabled` | boolean | `true` | Notes field visibility for negative-sentiment modal. Overridden by `behavior.feedback.showNotes`. Not applied in action mode. |
+| `components.feedback.positiveNotesEnabled` | boolean | `true` | Notes field visibility for positive-sentiment modal. Not applied in action mode. |
+| `components.feedback.negativeNotesEnabled` | boolean | `true` | Notes field visibility for negative-sentiment modal. Not applied in action mode. |
 
 ### Layout - Citations
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/feedback/FeedbackDialog.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/feedback/FeedbackDialog.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.R
 import com.adobe.marketing.mobile.concierge.ui.state.Feedback
 import com.adobe.marketing.mobile.concierge.ui.state.FeedbackType
-import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeFeedbackBehavior
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
 import com.adobe.marketing.mobile.concierge.ui.theme.FeedbackDisplayMode
@@ -149,17 +148,15 @@ private fun resolveQuestion(feedbackType: FeedbackType): String {
     }
 }
 
-/** Notes field visibility: `showNotes` when set, otherwise per-sentiment `positive/negativeNotesEnabled`. */
+/** Notes field visibility: per-sentiment `positive/negativeNotesEnabled` (defaults to `true`). */
 @Composable
 private fun resolveNotesEnabled(feedbackType: FeedbackType): Boolean {
     val componentsFeedback = ConciergeTheme.tokens?.components?.feedback
-    val sentimentFallback = if (feedbackType == FeedbackType.POSITIVE) {
+    return if (feedbackType == FeedbackType.POSITIVE) {
         componentsFeedback?.positiveNotesEnabled ?: true
     } else {
         componentsFeedback?.negativeNotesEnabled ?: true
     }
-    val behavior: ConciergeFeedbackBehavior? = ConciergeTheme.behavior?.feedback
-    return behavior?.resolvedShowNotes(sentimentFallback) ?: sentimentFallback
 }
 
 /** Close (X) button visibility: `true` for `"action"`, `false` for `"modal"` by default. */

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapper.kt
@@ -335,11 +335,6 @@ internal object CSSKeyMapper {
                 existing?.copy(checkboxBorder = color) ?: ConciergeFeedbackColors(checkboxBorder = color)
             }
         },
-        "feedback-notes-text-color" to { cssValue, theme ->
-            updateFeedbackColors(cssValue, theme) { existing, color ->
-                existing?.copy(notesText = color) ?: ConciergeFeedbackColors(notesText = color)
-            }
-        },
         "feedback-drag-handle-color" to { cssValue, theme ->
             updateFeedbackColors(cssValue, theme) { existing, color ->
                 existing?.copy(dragHandle = color) ?: ConciergeFeedbackColors(dragHandle = color)

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeColors.kt
@@ -86,7 +86,6 @@ data class ConciergeColors(
     val feedbackQuestionText: Color? = null,
     val feedbackOptionsText: Color? = null,
     val feedbackCheckboxBorder: Color? = null,
-    val feedbackNotesText: Color? = null,
     val feedbackDragHandle: Color? = null,
     val feedbackSubmitButtonFill: Color? = null,
     val feedbackSubmitButtonText: Color? = null,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -1173,8 +1173,8 @@ internal object ConciergeStyles {
             val titleColor = themeColors.feedbackTitleText ?: dialogTextColor
             val questionColor = themeColors.feedbackQuestionText ?: dialogTextColor.copy(alpha = 0.7f)
             val categoryTextColor = themeColors.feedbackOptionsText ?: dialogTextColor
-            val notesTextColor = themeColors.feedbackNotesText ?: dialogTextColor.copy(alpha = 0.7f)
-            val notesPlaceholderColor = themeColors.feedbackNotesText ?: dialogTextColor.copy(alpha = 0.5f)
+            val notesLabelColor = dialogTextColor.copy(alpha = 0.7f)
+            val notesPlaceholderColor = dialogTextColor.copy(alpha = 0.5f)
             // iOS reuses the checkbox outline for the notes editor outline when set.
             val textFieldBorder = themeColors.feedbackCheckboxBorder ?: dialogTextColor.copy(alpha = 0.2f)
 
@@ -1202,7 +1202,7 @@ internal object ConciergeStyles {
                 categoryTextColor = categoryTextColor,
                 categoriesNotesSpacing = 6.dp,
                 notesLabelStyle = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                notesLabelColor = notesTextColor,
+                notesLabelColor = notesLabelColor,
                 notesLabelSpacing = 8.dp,
                 notesPlaceholderStyle = MaterialTheme.typography.bodyMedium,
                 notesPlaceholderColor = notesPlaceholderColor,

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeModels.kt
@@ -218,8 +218,6 @@ data class ConciergeFeedbackColors(
     val optionsText: String? = null,
     /** Checkbox unchecked outline color; also reused for the notes editor outline. */
     val checkboxBorder: String? = null,
-    /** Notes label and placeholder color. */
-    val notesText: String? = null,
     /** Action sheet drag handle color. */
     val dragHandle: String? = null,
     /** Submit button fill color. */

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeThemeTokens.kt
@@ -339,18 +339,13 @@ data class ConciergeFeedbackBehavior(
     /** Overrides the close (X) button visibility. `null` defaults to `true` for `"action"`, `false` for `"modal"`. */
     val showCloseButton: Boolean? = null,
     /** Overrides the Cancel button visibility. `null` defaults to `true` for `"modal"`, `false` for `"action"`. */
-    val showCancelButton: Boolean? = null,
-    /** Overrides notes field visibility. `null` falls back to per-sentiment `positiveNotesEnabled` / `negativeNotesEnabled`. */
-    val showNotes: Boolean? = null
+    val showCancelButton: Boolean? = null
 ) {
     /** Effective close button visibility: `showCloseButton` when set, otherwise `displayMode == ACTION`. */
     fun resolvedShowCloseButton(): Boolean = showCloseButton ?: (displayMode == FeedbackDisplayMode.ACTION)
 
     /** Effective Cancel button visibility: `showCancelButton` when set, otherwise `displayMode == MODAL`. */
     fun resolvedShowCancelButton(): Boolean = showCancelButton ?: (displayMode == FeedbackDisplayMode.MODAL)
-
-    /** Notes field visibility: `showNotes` when set, otherwise the provided per-sentiment fallback. */
-    fun resolvedShowNotes(fallback: Boolean): Boolean = showNotes ?: fallback
 }
 
 /**

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParser.kt
@@ -355,7 +355,6 @@ internal object ThemeParser {
             feedbackQuestionText = themeColors.feedback?.questionText?.toComposeColor(),
             feedbackOptionsText = themeColors.feedback?.optionsText?.toComposeColor(),
             feedbackCheckboxBorder = themeColors.feedback?.checkboxBorder?.toComposeColor(),
-            feedbackNotesText = themeColors.feedback?.notesText?.toComposeColor(),
             feedbackDragHandle = themeColors.feedback?.dragHandle?.toComposeColor(),
             feedbackSubmitButtonFill = themeColors.feedback?.submitButtonFill?.toComposeColor(),
             feedbackSubmitButtonText = themeColors.feedback?.submitButtonText?.toComposeColor(),
@@ -444,8 +443,7 @@ internal object ThemeParser {
                 displayMode = FeedbackDisplayMode.fromString(DataReader.optString(it, "displayMode", "modal")),
                 thumbsPlacement = FeedbackThumbsPlacement.fromString(DataReader.optString(it, "thumbsPlacement", "inline")),
                 showCloseButton = it["showCloseButton"] as? Boolean,
-                showCancelButton = it["showCancelButton"] as? Boolean,
-                showNotes = it["showNotes"] as? Boolean
+                showCancelButton = it["showCancelButton"] as? Boolean
             )
         }
 

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/CSSKeyMapperTest.kt
@@ -64,7 +64,6 @@ class CSSKeyMapperTest {
             "feedback-question-text-color",
             "feedback-options-text-color",
             "feedback-checkbox-border-color",
-            "feedback-notes-text-color",
             "feedback-drag-handle-color",
             "feedback-submit-button-fill-color",
             "feedback-submit-button-text-color",
@@ -1121,12 +1120,6 @@ class CSSKeyMapperTest {
     }
 
     @Test
-    fun `apply maps feedback-notes-text-color`() {
-        val result = CSSKeyMapper.apply("--feedback-notes-text-color", "#131313", emptyTheme)
-        assertEquals("#131313", result.colors?.feedback?.notesText)
-    }
-
-    @Test
     fun `apply maps feedback-drag-handle-color`() {
         val result = CSSKeyMapper.apply("--feedback-drag-handle-color", "#CCCCCC", emptyTheme)
         assertEquals("#CCCCCC", result.colors?.feedback?.dragHandle)
@@ -1253,7 +1246,6 @@ class CSSKeyMapperTest {
             "feedback-question-text-color",
             "feedback-options-text-color",
             "feedback-checkbox-border-color",
-            "feedback-notes-text-color",
             "feedback-drag-handle-color",
             "feedback-submit-button-fill-color",
             "feedback-submit-button-text-color",

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeFeedbackBehaviorTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeFeedbackBehaviorTest.kt
@@ -19,8 +19,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Tests visibility defaults and overrides for the feedback close (X) and Cancel buttons,
- * and for the notes field. Mirrors the iOS `ConciergeFeedbackBehaviorTests` coverage.
+ * Tests visibility defaults and overrides for the feedback close (X) and Cancel buttons.
+ * Mirrors the iOS `ConciergeFeedbackBehaviorTests` coverage.
  */
 class ConciergeFeedbackBehaviorTest {
 
@@ -98,34 +98,6 @@ class ConciergeFeedbackBehaviorTest {
 
         assertNull(behavior.showCloseButton)
         assertNull(behavior.showCancelButton)
-        assertNull(behavior.showNotes)
-    }
-
-    // ========== showNotes resolver ==========
-
-    /** When `showNotes` is null, fall back to the per-sentiment value. */
-    @Test
-    fun `resolvedShowNotes null falls back to per sentiment fallback`() {
-        val behavior = ConciergeFeedbackBehavior(showNotes = null)
-
-        assertTrue(behavior.resolvedShowNotes(fallback = true))
-        assertFalse(behavior.resolvedShowNotes(fallback = false))
-    }
-
-    @Test
-    fun `resolvedShowNotes explicit true overrides fallback`() {
-        val behavior = ConciergeFeedbackBehavior(showNotes = true)
-
-        assertTrue(behavior.resolvedShowNotes(fallback = false))
-        assertTrue(behavior.resolvedShowNotes(fallback = true))
-    }
-
-    @Test
-    fun `resolvedShowNotes explicit false overrides fallback`() {
-        val behavior = ConciergeFeedbackBehavior(showNotes = false)
-
-        assertFalse(behavior.resolvedShowNotes(fallback = true))
-        assertFalse(behavior.resolvedShowNotes(fallback = false))
     }
 
     // ========== ConciergeFeedbackComponent per-sentiment flags ==========
@@ -160,14 +132,12 @@ class ConciergeFeedbackBehaviorTest {
         val original = ConciergeFeedbackBehavior(
             displayMode = FeedbackDisplayMode.ACTION,
             showCloseButton = false,
-            showCancelButton = true,
-            showNotes = false
+            showCancelButton = true
         )
         val updated = original.copy(displayMode = FeedbackDisplayMode.MODAL)
 
         assertEquals(FeedbackDisplayMode.MODAL, updated.displayMode)
         assertFalse(updated.showCloseButton!!)
         assertTrue(updated.showCancelButton!!)
-        assertFalse(updated.showNotes!!)
     }
 }

--- a/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
+++ b/code/concierge/src/test/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ThemeParserTest.kt
@@ -673,15 +673,14 @@ class ThemeParserTest {
     }
 
     @Test
-    fun `parseThemeTokens parses feedback behavior showCloseButton showCancelButton showNotes`() {
+    fun `parseThemeTokens parses feedback behavior showCloseButton and showCancelButton`() {
         val json = """
             {
                 "behavior": {
                     "feedback": {
                         "displayMode": "action",
                         "showCloseButton": false,
-                        "showCancelButton": true,
-                        "showNotes": false
+                        "showCancelButton": true
                     }
                 }
             }
@@ -694,7 +693,6 @@ class ThemeParserTest {
         assertEquals(FeedbackDisplayMode.ACTION, feedback?.displayMode)
         assertEquals(false, feedback?.showCloseButton)
         assertEquals(true, feedback?.showCancelButton)
-        assertEquals(false, feedback?.showNotes)
     }
 
     @Test
@@ -715,7 +713,6 @@ class ThemeParserTest {
         assertNotNull(feedback)
         assertNull(feedback?.showCloseButton)
         assertNull(feedback?.showCancelButton)
-        assertNull(feedback?.showNotes)
     }
 
     @Test
@@ -769,7 +766,6 @@ class ThemeParserTest {
                     "--feedback-question-text-color": "#424242",
                     "--feedback-options-text-color": "#222222",
                     "--feedback-checkbox-border-color": "#131313",
-                    "--feedback-notes-text-color": "#131313",
                     "--feedback-drag-handle-color": "#CCCCCC",
                     "--feedback-submit-button-fill-color": "#3B63FB",
                     "--feedback-submit-button-text-color": "#FFFFFF",
@@ -789,7 +785,6 @@ class ThemeParserTest {
         assertEquals("#424242", feedback?.questionText)
         assertEquals("#222222", feedback?.optionsText)
         assertEquals("#131313", feedback?.checkboxBorder)
-        assertEquals("#131313", feedback?.notesText)
         assertEquals("#CCCCCC", feedback?.dragHandle)
         assertEquals("#3B63FB", feedback?.submitButtonFill)
         assertEquals("#FFFFFF", feedback?.submitButtonText)

--- a/code/testapp/src/main/assets/themeDefault.json
+++ b/code/testapp/src/main/assets/themeDefault.json
@@ -28,22 +28,13 @@
     },
     "feedback": {
       "displayMode": "modal",
-      "thumbsPlacement": "inline",
-      "showCloseButton": null,
-      "showCancelButton": null,
-      "showNotes": null
+      "thumbsPlacement": "inline"
     },
     "citations": {
       "showLinkIcon": false
     },
     "welcomeCard": {
       "contentAlignment": "center"
-    }
-  },
-  "components": {
-    "feedback": {
-      "positiveNotesEnabled": true,
-      "negativeNotesEnabled": true
     }
   },
   "disclaimer": {
@@ -78,7 +69,7 @@
     "feedback.dialog.question.positive": "What went well? Select all that apply.",
     "feedback.dialog.question.negative": "What went wrong? Select all that apply.",
     "feedback.dialog.notes": "Notes",
-    "feedback.dialog.submit": "SUBMIT",
+    "feedback.dialog.submit": "Submit",
     "feedback.dialog.cancel": "Cancel",
     "feedback.dialog.notes.placeholder": "Additional notes (optional)",
     "feedback.toast.success": "Thank you for the feedback.",
@@ -181,26 +172,6 @@
     "--feedback-icon-btn-hover-background": "#FFFFFF",
     "--feedback-icon-btn-size-desktop": "32px",
     "--feedback-container-gap": "4px",
-    "--feedback-sheet-background-color": "#FFFFFF",
-    "--feedback-title-text-color": "#131313",
-    "--feedback-question-text-color": "#424242",
-    "--feedback-options-text-color": "#131313",
-    "--feedback-checkbox-border-color": "#131313",
-    "--feedback-notes-text-color": "#131313",
-    "--feedback-drag-handle-color": "#CCCCCC",
-    "--feedback-submit-button-fill-color": "#C55C19",
-    "--feedback-submit-button-text-color": "#FFFFFF",
-    "--feedback-submit-button-border-radius": "4px",
-    "--feedback-submit-button-font-weight": "700",
-    "--feedback-cancel-button-fill-color": "#FFFFFF",
-    "--feedback-cancel-button-text-color": "#2C2C2C",
-    "--feedback-cancel-button-border-color": "#2C2C2C",
-    "--feedback-cancel-button-border-width": "1px",
-    "--feedback-cancel-button-border-radius": "10px",
-    "--feedback-cancel-button-font-weight": "600",
-    "--feedback-checkbox-border-radius": "0px",
-    "--feedback-title-text-align": "center",
-    "--feedback-title-font-size": "18px",
     "--multimodal-card-box-shadow": "none",
     "--border-radius-card": "16px",
     "--button-height-s": "30px",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes two theme controls: the `behavior.feedback.showNotes` override flag and the `--feedback-notes-text-color` CSS token.
### Behavior
- `showNotes` field removed from `ConciergeFeedbackBehavior` and `ThemeParser`
- `resolvedShowNotes()` helper removed
- Notes field visibility reverts to per-sentiment `positiveNotesEnabled` / `negativeNotesEnabled` only
### Theming
- `--feedback-notes-text-color` CSS key removed from `CSSKeyMapper`
- `notesText` property removed from `ConciergeFeedbackColors` and `ConciergeColors`
- Notes label and placeholder color reverts to the `dialogTextColor` fallback in `ConciergeStyles`
### Tests
- `showNotes` cases removed from `ConciergeFeedbackBehaviorTest`
- `feedback-notes-text-color` key removed from `CSSKeyMapperTest`
- `ThemeParserTest` updated to remove `showNotes` parsing assertions

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
