### PR TITLE
Allow carousel to be scrolled outside the product card area and update padding

### DIFF
--- a/Documentation/style-guide.md
+++ b/Documentation/style-guide.md
@@ -799,7 +799,7 @@ When `behavior.productCard.cardStyle` is `"productDetail"`, product recommendati
 | `--product-card-text-top-padding` | `cssLayout.productCardTextTopPadding` | `Double` | `24.0` | Top padding for card text content (dp) |
 | `--product-card-text-bottom-padding` | `cssLayout.productCardTextBottomPadding` | `Double` | `16.0` | Bottom padding for card text content (dp) |
 | `--product-card-text-spacing` | `cssLayout.productCardTextSpacing` | `Double` | `8.0` | Gap between title and subtitle (dp) |
-| `--product-card-carousel-horizontal-padding` | `cssLayout.productCardCarouselHorizontalPadding` | `Double` | `4.0` | Carousel horizontal padding (dp) |
+| `--product-card-carousel-horizontal-padding` | `cssLayout.productCardCarouselHorizontalPadding` | `Double` | `0.0` | Extra trailing padding (dp) added to the carousel scroll content. Leading inset is always the 16dp base alignment inset only; trailing uses this value (falls back to `--chat-history-padding` when unset). |
 | `--product-card-carousel-spacing` | `cssLayout.productCardCarouselSpacing` | `Double` | `12.0` | Spacing between carousel cards (dp) |
 
 ### Layout - Buttons
@@ -1399,7 +1399,7 @@ Note: The feedback dialog checkbox uses `--color-primary` for the check box fill
 | `--product-card-text-top-padding` | ✅ | Extended product card text top padding | `ExtendedProductCard` |
 | `--product-card-text-bottom-padding` | ✅ | Extended product card text bottom padding | `ExtendedProductCard` |
 | `--product-card-text-spacing` | ✅ | Gap between title and subtitle | `ExtendedProductCard` |
-| `--product-card-carousel-horizontal-padding` | ✅ | Carousel horizontal padding | `ProductCarousel` |
+| `--product-card-carousel-horizontal-padding` | ✅ | Extra trailing inset only; leading is always the 16dp base inset | `ProductCarousel` |
 | `--product-card-carousel-spacing` | ✅ | Spacing between carousel cards | `ProductCarousel` |
 | `--button-height-s` | ⚠️ | Parsed but not used in composables | - |
 | `--cta-button-border-radius` | ✅ | CTA button corner radius | `CtaButton` |

--- a/code/concierge/src/androidTest/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItemTest.kt
+++ b/code/concierge/src/androidTest/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItemTest.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.concierge.ui.components.messages
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -500,6 +501,72 @@ class ChatMessageItemTest {
 
         composeTestRule.onNodeWithText("Tell me more").assertIsDisplayed()
         composeTestRule.onNodeWithText("Show deals").assertIsDisplayed()
+    }
+
+    // --- RenderMixedMessage — elements-only ---
+
+    @Test
+    fun chatMessageItem_mixedMessage_elementsOnly_displaysCarouselNavigation() {
+        // When there is no text, the Card branch is skipped entirely. The carousel
+        // should still render its navigation controls.
+        val message = ChatMessage(
+            content = MessageContent.Mixed(
+                text = "",
+                multimodalElements = listOf(
+                    MultimodalElement(id = "p1", url = "https://example.com/1.jpg", alttext = "Product 1"),
+                    MultimodalElement(id = "p2", url = "https://example.com/2.jpg", alttext = "Product 2")
+                )
+            ),
+            isFromUser = false,
+            timestamp = System.currentTimeMillis()
+        )
+
+        composeTestRule.setContent {
+            ConciergeTheme {
+                CompositionLocalProvider(LocalImageProvider provides DefaultImageProvider()) {
+                    ChatMessageItem(message = message)
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNode(hasContentDescription("Previous page")).assertIsDisplayed()
+        composeTestRule.onNode(hasContentDescription("Next page")).assertIsDisplayed()
+    }
+
+    @Test
+    fun chatMessageItem_mixedMessage_elementsOnly_withCompanyIcon_displaysCarouselNavigation() {
+        val theme = ConciergeThemeData(
+            config = ConciergeThemeConfig(),
+            tokens = ConciergeThemeTokens(
+                assets = ConciergeThemeAssets(
+                    icons = ConciergeIconAssets(company = "https://example.com/brand-icon.png")
+                )
+            )
+        )
+        val message = ChatMessage(
+            content = MessageContent.Mixed(
+                text = "",
+                multimodalElements = listOf(
+                    MultimodalElement(id = "p1", url = "https://example.com/1.jpg", alttext = "Product 1"),
+                    MultimodalElement(id = "p2", url = "https://example.com/2.jpg", alttext = "Product 2")
+                )
+            ),
+            isFromUser = false,
+            timestamp = System.currentTimeMillis()
+        )
+
+        composeTestRule.setContent {
+            ConciergeTheme(theme = theme) {
+                CompositionLocalProvider(LocalImageProvider provides DefaultImageProvider()) {
+                    ChatMessageItem(message = message)
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNode(hasContentDescription("Previous page")).assertIsDisplayed()
+        composeTestRule.onNode(hasContentDescription("Next page")).assertIsDisplayed()
     }
 
     // -----------------------------------------------------------------------

--- a/code/concierge/src/androidTest/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStylesTest.kt
+++ b/code/concierge/src/androidTest/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStylesTest.kt
@@ -440,4 +440,100 @@ class ConciergeStylesTest {
         composeTestRule.waitForIdle()
         assertEquals(Color(0xFFFF0000), style!!.dotColor)
     }
+
+    // -----------------------------------------------------------------------
+    // productCarouselStyle
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun productCarouselStyle_noTokens_trailingContentPaddingFallsBackTo4dp() {
+        var style: ConciergeStyles.ProductCarouselStyle? = null
+
+        composeTestRule.setContent {
+            ConciergeTheme {
+                style = ConciergeStyles.productCarouselStyle
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(style)
+        assertEquals(4.dp, style!!.trailingContentPadding)
+    }
+
+    @Test
+    fun productCarouselStyle_trailingContentPadding_usesChatHistoryPaddingWhenCarouselPaddingUnset() {
+        var style: ConciergeStyles.ProductCarouselStyle? = null
+        val themeData = ConciergeThemeData(
+            config = ConciergeThemeConfig(),
+            tokens = ConciergeThemeTokens(cssLayout = ConciergeLayout(chatHistoryPadding = 20.0))
+        )
+
+        composeTestRule.setContent {
+            ConciergeTheme(theme = themeData) {
+                style = ConciergeStyles.productCarouselStyle
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(style)
+        assertEquals(20.dp, style!!.trailingContentPadding)
+    }
+
+    @Test
+    fun productCarouselStyle_trailingContentPadding_usesCarouselHorizontalPaddingOverChatHistoryPadding() {
+        var style: ConciergeStyles.ProductCarouselStyle? = null
+        val themeData = ConciergeThemeData(
+            config = ConciergeThemeConfig(),
+            tokens = ConciergeThemeTokens(
+                cssLayout = ConciergeLayout(
+                    productCardCarouselHorizontalPadding = 8.0,
+                    chatHistoryPadding = 20.0
+                )
+            )
+        )
+
+        composeTestRule.setContent {
+            ConciergeTheme(theme = themeData) {
+                style = ConciergeStyles.productCarouselStyle
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(style)
+        assertEquals(8.dp, style!!.trailingContentPadding)
+    }
+
+    @Test
+    fun productCarouselStyle_itemSpacing_readsFromProductCardCarouselSpacing() {
+        var style: ConciergeStyles.ProductCarouselStyle? = null
+        val themeData = ConciergeThemeData(
+            config = ConciergeThemeConfig(),
+            tokens = ConciergeThemeTokens(cssLayout = ConciergeLayout(productCardCarouselSpacing = 16.0))
+        )
+
+        composeTestRule.setContent {
+            ConciergeTheme(theme = themeData) {
+                style = ConciergeStyles.productCarouselStyle
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(style)
+        assertEquals(16.dp, style!!.itemSpacing)
+    }
+
+    @Test
+    fun productCarouselStyle_noTokens_itemSpacingDefaultsTo12dp() {
+        var style: ConciergeStyles.ProductCarouselStyle? = null
+
+        composeTestRule.setContent {
+            ConciergeTheme {
+                style = ConciergeStyles.productCarouselStyle
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(style)
+        assertEquals(12.dp, style!!.itemSpacing)
+    }
 }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ConciergeConstants.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ConciergeConstants.kt
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.concierge
 internal object ConciergeConstants {
     const val EXTENSION_NAME = "brandconcierge"
     const val EXTENSION_FRIENDLY_NAME = "BrandConcierge"
-    const val VERSION = "3.5.0"
+    const val VERSION = "3.5.1"
     const val LOG_TAG = "BrandConcierge"
     const val DATA_STORE_NAME = EXTENSION_NAME
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/card/ProductCarousel.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/card/ProductCarousel.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.ui.theme.CarouselStyle
 import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeStyles
@@ -51,7 +53,8 @@ import com.adobe.marketing.mobile.concierge.ui.theme.ConciergeTheme
 internal fun ProductCarousel(
     elements: List<MultimodalElement>,
     onImageClick: (MultimodalElement) -> Unit,
-    useExtendedProductCards: Boolean = false
+    useExtendedProductCards: Boolean = false,
+    leadingInset: Dp = 0.dp
 ) {
     val style = ConciergeStyles.productCarouselStyle
     val extendedProductCardStyle = ConciergeStyles.extendedProductCardStyle
@@ -69,8 +72,8 @@ internal fun ProductCarousel(
         LazyRow(
             state = listState,
             contentPadding = PaddingValues(
-                start = style.horizontalPadding,
-                end = if (isPaged) itemWidth else style.horizontalPadding,
+                start = leadingInset,
+                end = if (isPaged) itemWidth else style.trailingContentPadding,
                 top = style.verticalPadding,
                 bottom = style.verticalPadding
             ),

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/card/RecommendationCards.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/card/RecommendationCards.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.ConciergeConstants
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.ui.theme.CardsAlignment
@@ -39,7 +41,8 @@ internal fun RecommendationCards(
     elements: List<MultimodalElement>,
     modifier: Modifier = Modifier,
     onImageClick: (MultimodalElement) -> Unit = {},
-    onActionClick: (ProductActionButton) -> Unit = {}
+    onActionClick: (ProductActionButton) -> Unit = {},
+    leadingInset: Dp = 0.dp
 ) {
     if (elements.isEmpty()) {
         Log.debug(ConciergeConstants.EXTENSION_NAME, TAG, "No elements to display, returning early")
@@ -85,7 +88,8 @@ internal fun RecommendationCards(
                 ProductCarousel(
                     elements = elements,
                     onImageClick = onImageClick,
-                    useExtendedProductCards = useExtendedProductCards
+                    useExtendedProductCards = useExtendedProductCards,
+                    leadingInset = leadingInset
                 )
             }
         }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/messages/ChatMessageItem.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.concierge.network.MultimodalElement
 import com.adobe.marketing.mobile.concierge.ui.components.card.ProductActionButton
@@ -310,6 +312,24 @@ private fun RenderMixedMessage(
     val companyIconName = if (!message.isFromUser) ConciergeTheme.tokens?.assets?.icons?.company?.takeIf { it.isNotEmpty() } else null
     val messageAlignment = ConciergeTheme.behavior?.chat?.messageAlignment ?: ConciergeTextAlignment.START
 
+    val hasText = content.text.isNotEmpty()
+    val hasElements = !content.multimodalElements.isNullOrEmpty()
+    val contentPad = if (companyIconName != null) 0.dp else style.innerPadding
+
+    // MessageList applies padding(horizontal = listPadding) to every item. The layout modifier on
+    // the carousel Box escapes that constraint by measuring at full screen width and placing the
+    // content at a negative offset so it aligns with the screen edges.
+    val listPadding = ConciergeStyles.messageListStyle.horizontalPadding
+    val escapeLeft: Dp = listPadding + if (companyIconName != null) {
+        style.agentIconSize + style.agentIconSpacing
+    } else 0.dp
+    val escapeRight: Dp = listPadding
+
+    // First card aligns with the text content: escapeLeft + innerPadding (no icon) or escapeLeft
+    // alone (with icon). style.padding (card outer padding) is excluded because the carousel
+    // renders outside the card wrapper.
+    val carouselLeadingInset: Dp = escapeLeft + if (companyIconName == null) style.innerPadding else 0.dp
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -318,70 +338,98 @@ private fun RenderMixedMessage(
                 else Modifier
             )
     ) {
-        Card(
-            modifier = Modifier
-                .then(messageAlignment.toModifier())
-                .padding(
-                    top = if (companyIconName != null) 0.dp else style.padding,
-                    bottom = style.padding,
-                    end = style.padding,
-                    start = if (companyIconName != null) 0.dp else style.padding
-                ),
-            colors = CardDefaults.cardColors(
-                containerColor = style.botMessageBackgroundColor
-            ),
-            elevation = CardDefaults.cardElevation(defaultElevation = style.elevation),
-            shape = style.shape
-        ) {
-            Box(
+        // Text and footer stay inside the Card so they retain the message bubble background and shape.
+        // The carousel is rendered as a sibling outside the Card so its LazyRow is not clipped by
+        // the card's shape during horizontal scroll.
+        if (hasText || message.hasFooterContent) {
+            Card(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .then(messageAlignment.toModifier())
                     .padding(
-                        top = if (companyIconName != null) 0.dp else style.innerPadding,
-                        bottom = style.innerPadding,
-                        end = style.innerPadding,
-                        start = if (companyIconName != null) 0.dp else style.innerPadding
-                    )
+                        top = if (companyIconName != null) 0.dp else style.padding,
+                        bottom = style.padding,
+                        end = style.padding,
+                        start = if (companyIconName != null) 0.dp else style.padding
+                    ),
+                colors = CardDefaults.cardColors(
+                    containerColor = style.botMessageBackgroundColor
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = style.elevation),
+                shape = style.shape
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {
-                    // Render text content if present
-                    if (content.text.isNotEmpty()) {
-                        ConciergeResponse(
-                            text = content.text,
-                            sources = message.citations ?: emptyList(),
-                            handleLink = handleLink,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-
-                    // Add spacing between text and recommendation cards if both are present
-                    if (content.text.isNotEmpty() && !content.multimodalElements.isNullOrEmpty()) {
-                        Spacer(modifier = Modifier.height(style.contentSpacing))
-                    }
-
-                    // Render multi-modal elements if present
-                    content.multimodalElements?.let { multimodalElements ->
-                        if (multimodalElements.isNotEmpty()) {
-                            RecommendationCards(
-                                elements = multimodalElements,
-                                onImageClick = onImageClick,
-                                onActionClick = onActionClick
+                    if (hasText) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = contentPad,
+                                    bottom = if (!message.hasFooterContent) style.innerPadding else 0.dp,
+                                    start = contentPad,
+                                    end = style.innerPadding
+                                )
+                        ) {
+                            ConciergeResponse(
+                                text = content.text,
+                                sources = message.citations ?: emptyList(),
+                                handleLink = handleLink,
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                     }
 
-                    // Show footer if we have citations or have an interaction id for providing feedback
                     if (message.hasFooterContent) {
-                        ChatFooter(
-                            citations = message.citations,
-                            uniqueCitations = message.uniqueCitations,
-                            interactionId = message.interactionId,
-                            sseComplete = message.sseComplete,
-                            onFeedback = onFeedback,
-                            handleLink = handleLink,
-                            feedbackState = feedbackState
-                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = if (!hasText) contentPad else 0.dp,
+                                    bottom = style.innerPadding,
+                                    start = contentPad,
+                                    end = style.innerPadding
+                                )
+                        ) {
+                            ChatFooter(
+                                citations = message.citations,
+                                uniqueCitations = message.uniqueCitations,
+                                interactionId = message.interactionId,
+                                sseComplete = message.sseComplete,
+                                onFeedback = onFeedback,
+                                handleLink = handleLink,
+                                feedbackState = feedbackState
+                            )
+                        }
                     }
+                }
+            }
+        }
+
+        if ((hasText || message.hasFooterContent) && hasElements) {
+            Spacer(modifier = Modifier.height(style.contentSpacing))
+        }
+
+        content.multimodalElements?.let { multimodalElements ->
+            if (multimodalElements.isNotEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .layout { measurable, constraints ->
+                            val leftPx = escapeLeft.roundToPx()
+                            val rightPx = escapeRight.roundToPx()
+                            val placeable = measurable.measure(
+                                constraints.copy(maxWidth = constraints.maxWidth + leftPx + rightPx)
+                            )
+                            layout(constraints.maxWidth, placeable.height) {
+                                placeable.place(-leftPx, 0)
+                            }
+                        }
+                ) {
+                    RecommendationCards(
+                        elements = multimodalElements,
+                        onImageClick = onImageClick,
+                        onActionClick = onActionClick,
+                        leadingInset = carouselLeadingInset
+                    )
                 }
             }
         }

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/theme/ConciergeStyles.kt
@@ -412,7 +412,7 @@ internal object ConciergeStyles {
     @Immutable
     data class ProductCarouselStyle(
         val itemSpacing: Dp,
-        val horizontalPadding: Dp,
+        val trailingContentPadding: Dp,
         val verticalPadding: Dp,
         val imageWidth: Dp,
         val imageHeight: Dp,
@@ -431,7 +431,7 @@ internal object ConciergeStyles {
         @Composable get() {
             val themeColors = ConciergeTheme.colors
             val layout = ConciergeTheme.tokens?.cssLayout
-            val carouselHorizontalPadding = (
+            val carouselTrailingPadding = (
                 layout?.productCardCarouselHorizontalPadding
                     ?: layout?.chatHistoryPadding
                     ?: 4.0
@@ -439,7 +439,7 @@ internal object ConciergeStyles {
             val carouselItemSpacing = (layout?.productCardCarouselSpacing ?: 12.0).toFloat().dp
             return ProductCarouselStyle(
                 itemSpacing = carouselItemSpacing,
-                horizontalPadding = carouselHorizontalPadding,
+                trailingContentPadding = carouselTrailingPadding,
                 verticalPadding = 8.dp,
                 imageWidth = 200.dp,
                 imageHeight = 150.dp,

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 moduleName=concierge
-moduleVersion=3.5.0
+moduleVersion=3.5.1
 
 mavenCoreVersion=3.5.0
 mavenEdgeVersion=3.0.2


### PR DESCRIPTION
## Description

Fixes product carousel scrolling so cards are not clipped at the edges of the screen during horizontal scroll, and aligns the first card's leading position with the agent response text above it.

The carousel is moved outside the message `Card` composable (which clipped its children to the card's shape) and rendered as a sibling in the layout. A custom `layout` modifier expands the carousel to full screen width and offsets it so it aligns with the screen edges, escaping the horizontal padding that `MessageList` applies to every item. A `leadingInset` parameter is computed from `listPadding + innerPadding` (no icon) or `listPadding + iconOffset` (with icon) so the first card aligns with the text content above it in both icon and no-icon configurations.

`ProductCarouselStyle.horizontalPadding` is replaced with `trailingContentPadding`, which falls back to `--chat-history-padding` then `4dp` when `--product-card-carousel-horizontal-padding` is not set. The leading inset is always derived from the layout at the call site and is no longer a style property.

## Motivation and Context

Product cards in a carousel were being clipped at the left and right edges of the screen during horizontal scrolling, preventing the intended full-width scroll behavior. The first card was also misaligned with the agent response text above it.

## How Has This Been Tested?

- New Android instrumentation tests added:
  - `ConciergeStylesTest` — `productCarouselStyle` trailing content padding fallback chain (`--product-card-carousel-horizontal-padding` → `--chat-history-padding` → `4dp`) and item spacing default/override
  - `ChatMessageItemTest` — elements-only mixed message (no text) renders carousel navigation controls with and without a company icon configured
- Existing `ProductCarouselTest`, `RecommendationCardsTest`, and `ChatMessageItemTest` suites pass
- Manually verified on device: cards scroll to the edges of the screen without clipping, and the first card aligns with the agent response text in both icon and no-icon themes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
