### PR TITLE
Update Concierge extension Material version; require citations to be present before showing feedback thumbs

### DIFF
--- a/code/concierge/build.gradle.kts
+++ b/code/concierge/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 
 val mavenCoreVersion: String by project
 val mavenEdgeIdentityVersion: String by project
-val material3Version = "1.2.0"
+val material3Version = "1.3.0"
 
 aepLibrary {
     namespace = "com.adobe.marketing.mobile.concierge"
@@ -44,6 +44,12 @@ aepLibrary {
         addMavenDependency("androidx.appcompat", "appcompat", BuildConstants.Versions.ANDROIDX_APPCOMPAT)
         addMavenDependency("androidx.compose.runtime", "runtime", BuildConstants.Versions.COMPOSE)
         addMavenDependency("androidx.activity", "activity-compose", BuildConstants.Versions.ANDROIDX_ACTIVITY_COMPOSE)
+    }
+}
+
+configurations.configureEach {
+    resolutionStrategy {
+        force("androidx.compose.material3:material3:$material3Version")
     }
 }
 

--- a/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/footer/ChatFooter.kt
+++ b/code/concierge/src/main/kotlin/com/adobe/marketing/mobile/concierge/ui/components/footer/ChatFooter.kt
@@ -58,7 +58,7 @@ internal fun ChatFooter(
     feedbackState: FeedbackState = FeedbackState.None
 ) {
     val hasCitations = !citations.isNullOrEmpty()
-    val showFeedbackButtons = !interactionId.isNullOrEmpty() && sseComplete
+    val showFeedbackButtons = hasCitations && !interactionId.isNullOrEmpty() && sseComplete
     var sourcesExpanded by remember { mutableStateOf(false) }
     val thumbsPlacement = ConciergeTheme.behavior?.feedback?.thumbsPlacement
         ?: FeedbackThumbsPlacement.INLINE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Update Material3 to 1.3.0 and force its resolution to ensure a consistent Compose Material3 dependency. This resolves a crash which was occurring to `rememberModalBottomSheetState` function signature differences.
- Change ChatFooter to only show feedback buttons when citations are present (in addition to interactionId and sseComplete) so feedback UI only appears when sources exist.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
